### PR TITLE
Add support for lists in the openapi specification

### DIFF
--- a/internal/openapi/ent/migrate/schema.go
+++ b/internal/openapi/ent/migrate/schema.go
@@ -35,6 +35,7 @@ var (
 	PetsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
+		{Name: "nicknames", Type: field.TypeJSON, Nullable: true},
 		{Name: "age", Type: field.TypeInt, Nullable: true},
 		{Name: "owner_pets", Type: field.TypeInt, Nullable: true},
 	}
@@ -46,7 +47,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "pets_owners_pets",
-				Columns:    []*schema.Column{PetsColumns[3]},
+				Columns:    []*schema.Column{PetsColumns[4]},
 				RefColumns: []*schema.Column{OwnersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},

--- a/internal/openapi/ent/mutation.go
+++ b/internal/openapi/ent/mutation.go
@@ -896,6 +896,7 @@ type PetMutation struct {
 	typ               string
 	id                *int
 	name              *string
+	nicknames         *[]string
 	age               *int
 	addage            *int
 	clearedFields     map[string]struct{}
@@ -1025,6 +1026,55 @@ func (m *PetMutation) OldName(ctx context.Context) (v string, err error) {
 // ResetName resets all changes to the "name" field.
 func (m *PetMutation) ResetName() {
 	m.name = nil
+}
+
+// SetNicknames sets the "nicknames" field.
+func (m *PetMutation) SetNicknames(s []string) {
+	m.nicknames = &s
+}
+
+// Nicknames returns the value of the "nicknames" field in the mutation.
+func (m *PetMutation) Nicknames() (r []string, exists bool) {
+	v := m.nicknames
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNicknames returns the old "nicknames" field's value of the Pet entity.
+// If the Pet object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PetMutation) OldNicknames(ctx context.Context) (v []string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, fmt.Errorf("OldNicknames is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, fmt.Errorf("OldNicknames requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNicknames: %w", err)
+	}
+	return oldValue.Nicknames, nil
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (m *PetMutation) ClearNicknames() {
+	m.nicknames = nil
+	m.clearedFields[pet.FieldNicknames] = struct{}{}
+}
+
+// NicknamesCleared returns if the "nicknames" field was cleared in this mutation.
+func (m *PetMutation) NicknamesCleared() bool {
+	_, ok := m.clearedFields[pet.FieldNicknames]
+	return ok
+}
+
+// ResetNicknames resets all changes to the "nicknames" field.
+func (m *PetMutation) ResetNicknames() {
+	m.nicknames = nil
+	delete(m.clearedFields, pet.FieldNicknames)
 }
 
 // SetAge sets the "age" field.
@@ -1263,9 +1313,12 @@ func (m *PetMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PetMutation) Fields() []string {
-	fields := make([]string, 0, 2)
+	fields := make([]string, 0, 3)
 	if m.name != nil {
 		fields = append(fields, pet.FieldName)
+	}
+	if m.nicknames != nil {
+		fields = append(fields, pet.FieldNicknames)
 	}
 	if m.age != nil {
 		fields = append(fields, pet.FieldAge)
@@ -1280,6 +1333,8 @@ func (m *PetMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case pet.FieldName:
 		return m.Name()
+	case pet.FieldNicknames:
+		return m.Nicknames()
 	case pet.FieldAge:
 		return m.Age()
 	}
@@ -1293,6 +1348,8 @@ func (m *PetMutation) OldField(ctx context.Context, name string) (ent.Value, err
 	switch name {
 	case pet.FieldName:
 		return m.OldName(ctx)
+	case pet.FieldNicknames:
+		return m.OldNicknames(ctx)
 	case pet.FieldAge:
 		return m.OldAge(ctx)
 	}
@@ -1310,6 +1367,13 @@ func (m *PetMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetName(v)
+		return nil
+	case pet.FieldNicknames:
+		v, ok := value.([]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNicknames(v)
 		return nil
 	case pet.FieldAge:
 		v, ok := value.(int)
@@ -1363,6 +1427,9 @@ func (m *PetMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *PetMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(pet.FieldNicknames) {
+		fields = append(fields, pet.FieldNicknames)
+	}
 	if m.FieldCleared(pet.FieldAge) {
 		fields = append(fields, pet.FieldAge)
 	}
@@ -1380,6 +1447,9 @@ func (m *PetMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *PetMutation) ClearField(name string) error {
 	switch name {
+	case pet.FieldNicknames:
+		m.ClearNicknames()
+		return nil
 	case pet.FieldAge:
 		m.ClearAge()
 		return nil
@@ -1393,6 +1463,9 @@ func (m *PetMutation) ResetField(name string) error {
 	switch name {
 	case pet.FieldName:
 		m.ResetName()
+		return nil
+	case pet.FieldNicknames:
+		m.ResetNicknames()
 		return nil
 	case pet.FieldAge:
 		m.ResetAge()

--- a/internal/openapi/ent/openapi.json
+++ b/internal/openapi/ent/openapi.json
@@ -304,7 +304,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/Pet2903321980View"
                   }
                 }
               }
@@ -626,7 +626,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/Pet2903321980View"
                   }
                 }
               }
@@ -680,7 +680,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/Pet2903321980View"
                   }
                 }
               }
@@ -742,6 +742,12 @@
                     "type": "string",
                     "example": "Kuro"
                   },
+                  "nicknames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "owner": {
                     "type": "integer",
                     "format": "int32"
@@ -757,7 +763,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet359800019View"
+                  "$ref": "#/components/schemas/Pet2903321980View"
                 }
               }
             }
@@ -914,6 +920,12 @@
                     "type": "string",
                     "example": "Kuro"
                   },
+                  "nicknames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "owner": {
                     "type": "integer",
                     "format": "int32"
@@ -929,7 +941,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet359800019View"
+                  "$ref": "#/components/schemas/Pet2903321980View"
                 }
               }
             }
@@ -1061,7 +1073,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/Pet2903321980View"
                   }
                 }
               }
@@ -1175,10 +1187,8 @@
             "example": 1
           },
           "friends": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Pet359800019View"
-            }
+            "type": "object",
+            "properties": {}
           },
           "id": {
             "type": "integer",
@@ -1193,7 +1203,7 @@
           }
         }
       },
-      "Pet359800019View": {
+      "Pet2903321980View": {
         "type": "object",
         "required": [
           "id",
@@ -1212,6 +1222,12 @@
           "name": {
             "type": "string",
             "example": "Kuro"
+          },
+          "nicknames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/internal/openapi/ent/pet/pet.go
+++ b/internal/openapi/ent/pet/pet.go
@@ -9,6 +9,8 @@ const (
 	FieldID = "id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
+	// FieldNicknames holds the string denoting the nicknames field in the database.
+	FieldNicknames = "nicknames"
 	// FieldAge holds the string denoting the age field in the database.
 	FieldAge = "age"
 	// EdgeCategories holds the string denoting the categories edge name in mutations.
@@ -39,6 +41,7 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldName,
+	FieldNicknames,
 	FieldAge,
 }
 

--- a/internal/openapi/ent/pet/where.go
+++ b/internal/openapi/ent/pet/where.go
@@ -216,6 +216,20 @@ func NameContainsFold(v string) predicate.Pet {
 	})
 }
 
+// NicknamesIsNil applies the IsNil predicate on the "nicknames" field.
+func NicknamesIsNil() predicate.Pet {
+	return predicate.Pet(func(s *sql.Selector) {
+		s.Where(sql.IsNull(s.C(FieldNicknames)))
+	})
+}
+
+// NicknamesNotNil applies the NotNil predicate on the "nicknames" field.
+func NicknamesNotNil() predicate.Pet {
+	return predicate.Pet(func(s *sql.Selector) {
+		s.Where(sql.NotNull(s.C(FieldNicknames)))
+	})
+}
+
 // AgeEQ applies the EQ predicate on the "age" field.
 func AgeEQ(v int) predicate.Pet {
 	return predicate.Pet(func(s *sql.Selector) {

--- a/internal/openapi/ent/pet_create.go
+++ b/internal/openapi/ent/pet_create.go
@@ -27,6 +27,12 @@ func (pc *PetCreate) SetName(s string) *PetCreate {
 	return pc
 }
 
+// SetNicknames sets the "nicknames" field.
+func (pc *PetCreate) SetNicknames(s []string) *PetCreate {
+	pc.mutation.SetNicknames(s)
+	return pc
+}
+
 // SetAge sets the "age" field.
 func (pc *PetCreate) SetAge(i int) *PetCreate {
 	pc.mutation.SetAge(i)
@@ -197,6 +203,14 @@ func (pc *PetCreate) createSpec() (*Pet, *sqlgraph.CreateSpec) {
 			Column: pet.FieldName,
 		})
 		_node.Name = value
+	}
+	if value, ok := pc.mutation.Nicknames(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: pet.FieldNicknames,
+		})
+		_node.Nicknames = value
 	}
 	if value, ok := pc.mutation.Age(); ok {
 		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{

--- a/internal/openapi/ent/pet_update.go
+++ b/internal/openapi/ent/pet_update.go
@@ -34,6 +34,18 @@ func (pu *PetUpdate) SetName(s string) *PetUpdate {
 	return pu
 }
 
+// SetNicknames sets the "nicknames" field.
+func (pu *PetUpdate) SetNicknames(s []string) *PetUpdate {
+	pu.mutation.SetNicknames(s)
+	return pu
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (pu *PetUpdate) ClearNicknames() *PetUpdate {
+	pu.mutation.ClearNicknames()
+	return pu
+}
+
 // SetAge sets the "age" field.
 func (pu *PetUpdate) SetAge(i int) *PetUpdate {
 	pu.mutation.ResetAge()
@@ -242,6 +254,19 @@ func (pu *PetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: pet.FieldName,
 		})
 	}
+	if value, ok := pu.mutation.Nicknames(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: pet.FieldNicknames,
+		})
+	}
+	if pu.mutation.NicknamesCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Column: pet.FieldNicknames,
+		})
+	}
 	if value, ok := pu.mutation.Age(); ok {
 		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
@@ -427,6 +452,18 @@ type PetUpdateOne struct {
 // SetName sets the "name" field.
 func (puo *PetUpdateOne) SetName(s string) *PetUpdateOne {
 	puo.mutation.SetName(s)
+	return puo
+}
+
+// SetNicknames sets the "nicknames" field.
+func (puo *PetUpdateOne) SetNicknames(s []string) *PetUpdateOne {
+	puo.mutation.SetNicknames(s)
+	return puo
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (puo *PetUpdateOne) ClearNicknames() *PetUpdateOne {
+	puo.mutation.ClearNicknames()
 	return puo
 }
 
@@ -660,6 +697,19 @@ func (puo *PetUpdateOne) sqlSave(ctx context.Context) (_node *Pet, err error) {
 			Type:   field.TypeString,
 			Value:  value,
 			Column: pet.FieldName,
+		})
+	}
+	if value, ok := puo.mutation.Nicknames(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Value:  value,
+			Column: pet.FieldNicknames,
+		})
+	}
+	if puo.mutation.NicknamesCleared() {
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
+			Type:   field.TypeJSON,
+			Column: pet.FieldNicknames,
 		})
 	}
 	if value, ok := puo.mutation.Age(); ok {

--- a/internal/openapi/ent/schema/pet.go
+++ b/internal/openapi/ent/schema/pet.go
@@ -22,6 +22,9 @@ func (Pet) Fields() []ent.Field {
 				elk.Groups("pet"),
 				elk.Example("Kuro"),
 			),
+		field.JSON("nicknames", []string{}).
+			Optional().
+			Annotations(elk.Groups("pet:read")),
 		field.Int("age").
 			Optional().
 			Annotations(

--- a/internal/pets/ent/entc.go
+++ b/internal/pets/ent/entc.go
@@ -11,7 +11,10 @@ import (
 )
 
 func main() {
-	ex, err := elk.NewExtension(elk.GenerateHandlers())
+	ex, err := elk.NewExtension(
+		elk.GenerateHandlers(),
+		elk.GenerateSpec("openapi.json"),
+	)
 	if err != nil {
 		log.Fatalf("creating elk extension: %v", err)
 	}

--- a/internal/pets/ent/entc.go
+++ b/internal/pets/ent/entc.go
@@ -13,7 +13,6 @@ import (
 func main() {
 	ex, err := elk.NewExtension(
 		elk.GenerateHandlers(),
-		elk.GenerateSpec("openapi.json"),
 	)
 	if err != nil {
 		log.Fatalf("creating elk extension: %v", err)

--- a/openapi.go
+++ b/openapi.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -673,9 +674,23 @@ func oasType(f *gen.Field) (*spec.Type, error) {
 	if f.IsEnum() {
 		return _string, nil
 	}
-	t, ok := oasTypes[f.Type.String()]
+
+	s := f.Type.String()
+	if strings.Contains(s, "[]") {
+		ending := strings.Replace(s, "[]", "", 1)
+		t, ok := oasTypes[ending]
+		if !ok {
+			return nil, fmt.Errorf("no OAS-type exists for %q", s)
+		}
+		return &spec.Type{
+			Type:   "array",
+			Format: t.Format,
+			Items:  t,
+		}, nil
+	}
+	t, ok := oasTypes[s]
 	if !ok {
-		return nil, fmt.Errorf("no OAS-type exists for %q", f.Type.String())
+		return nil, fmt.Errorf("no OAS-type exists for %q", s)
 	}
 	return t, nil
 }

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -100,7 +100,7 @@ type (
 	Type struct {
 		Type   string      `json:"type,omitempty"`
 		Format string      `json:"format,omitempty"`
-		Items  interface{} `json:"items,omitempty"` // of type `Type`, but recursive types are not valid.
+		Items  *Type `json:"items,omitempty"`
 	}
 	Edges map[string]Edge
 	Edge  struct {

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -98,8 +98,9 @@ type (
 		Example  interface{} `json:"example,omitempty"`
 	}
 	Type struct {
-		Type   string `json:"type"`
-		Format string `json:"format,omitempty"`
+		Type   string      `json:"type,omitempty"`
+		Format string      `json:"format,omitempty"`
+		Items  interface{} `json:"items,omitempty"` // of type `Type`, but recursive types are not valid.
 	}
 	Edges map[string]Edge
 	Edge  struct {


### PR DESCRIPTION
The pets example has lists in it, which could not render into openapi due to lack of support for slice types.