### PR TITLE
Feature/smarter names

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -39,9 +39,11 @@ type SchemaAnnotation struct {
 	ListSecurity spec.Security
 }
 
+const elkSchemaName = "ElkSchema"
+
 // Name implements ent.Annotation interface.
 func (SchemaAnnotation) Name() string {
-	return "ElkSchema"
+	return elkSchemaName
 }
 
 // Merge implements ent.Merger interface.

--- a/internal/client_gen/ent/http/create.go
+++ b/internal/client_gen/ent/http/create.go
@@ -63,7 +63,7 @@ func (h CategoryHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("category rendered", zap.Uint64("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247View(ret), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(ret), w)
 }
 
 // Create creates a new ent.Collar and stores it in the database.
@@ -115,7 +115,7 @@ func (h CollarHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collar rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(ret), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(ret), w)
 }
 
 // Create creates a new ent.Owner and stores it in the database.
@@ -170,7 +170,7 @@ func (h OwnerHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owner rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(ret), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(ret), w)
 }
 
 // Create creates a new ent.Pet and stores it in the database.
@@ -234,5 +234,5 @@ func (h PetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019View(ret), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(ret), w)
 }

--- a/internal/client_gen/ent/http/easyjson.go
+++ b/internal/client_gen/ent/http/easyjson.go
@@ -19,7 +19,71 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp(in *jlexer.Lexer, out *PetUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp(in *jlexer.Lexer, out *PetWithOwnerAndPetOwnerViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PetWithOwnerAndPetOwnerViews, 0, 8)
+			} else {
+				*out = PetWithOwnerAndPetOwnerViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v1 *PetWithOwnerAndPetOwnerView
+			if in.IsNull() {
+				in.Skip()
+				v1 = nil
+			} else {
+				if v1 == nil {
+					v1 = new(PetWithOwnerAndPetOwnerView)
+				}
+				(*v1).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v1)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp(out *jwriter.Writer, in PetWithOwnerAndPetOwnerViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v2, v3 := range in {
+			if v2 > 0 {
+				out.RawByte(',')
+			}
+			if v3 == nil {
+				out.RawString("null")
+			} else {
+				(*v3).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetWithOwnerAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetWithOwnerAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp1(in *jlexer.Lexer, out *PetWithOwnerAndPetOwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -38,94 +102,24 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp(in *jle
 			continue
 		}
 		switch key {
+		case "id":
+			out.ID = string(in.String())
 		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
+			out.Name = string(in.String())
 		case "age":
-			if in.IsNull() {
-				in.Skip()
-				out.Age = nil
-			} else {
-				if out.Age == nil {
-					out.Age = new(int)
-				}
-				*out.Age = int(in.Int())
-			}
-		case "collar":
-			if in.IsNull() {
-				in.Skip()
-				out.Collar = nil
-			} else {
-				if out.Collar == nil {
-					out.Collar = new(int)
-				}
-				*out.Collar = int(in.Int())
-			}
-		case "categories":
-			if in.IsNull() {
-				in.Skip()
-				out.Categories = nil
-			} else {
-				in.Delim('[')
-				if out.Categories == nil {
-					if !in.IsDelim(']') {
-						out.Categories = make([]uint64, 0, 8)
-					} else {
-						out.Categories = []uint64{}
-					}
-				} else {
-					out.Categories = (out.Categories)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v1 uint64
-					v1 = uint64(in.Uint64())
-					out.Categories = append(out.Categories, v1)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
+			out.Age = int(in.Int())
 		case "owner":
 			if in.IsNull() {
 				in.Skip()
 				out.Owner = nil
 			} else {
 				if out.Owner == nil {
-					out.Owner = new(uuid.UUID)
+					out.Owner = new(OwnerWithPetAndPetOwnerView)
 				}
-				if data := in.UnsafeBytes(); in.Ok() {
-					in.AddError((*out.Owner).UnmarshalText(data))
-				}
+				(*out.Owner).UnmarshalEasyJSON(in)
 			}
 		case "friends":
-			if in.IsNull() {
-				in.Skip()
-				out.Friends = nil
-			} else {
-				in.Delim('[')
-				if out.Friends == nil {
-					if !in.IsDelim(']') {
-						out.Friends = make([]string, 0, 4)
-					} else {
-						out.Friends = []string{}
-					}
-				} else {
-					out.Friends = (out.Friends)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v2 string
-					v2 = string(in.String())
-					out.Friends = append(out.Friends, v2)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
+			(out.Friends).UnmarshalEasyJSON(in)
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -140,91 +134,214 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp(in *jle
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp(out *jwriter.Writer, in PetUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp1(out *jwriter.Writer, in PetWithOwnerAndPetOwnerView) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	{
-		const prefix string = ",\"name\":"
+	if in.ID != "" {
+		const prefix string = ",\"id\":"
+		first = false
 		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
+		out.String(string(in.ID))
 	}
-	{
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if in.Age != 0 {
 		const prefix string = ",\"age\":"
-		out.RawString(prefix)
-		if in.Age == nil {
-			out.RawString("null")
+		if first {
+			first = false
+			out.RawString(prefix[1:])
 		} else {
-			out.Int(int(*in.Age))
+			out.RawString(prefix)
 		}
+		out.Int(int(in.Age))
 	}
-	{
-		const prefix string = ",\"collar\":"
-		out.RawString(prefix)
-		if in.Collar == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Collar))
-		}
-	}
-	{
-		const prefix string = ",\"categories\":"
-		out.RawString(prefix)
-		if in.Categories == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v3, v4 := range in.Categories {
-				if v3 > 0 {
-					out.RawByte(',')
-				}
-				out.Uint64(uint64(v4))
-			}
-			out.RawByte(']')
-		}
-	}
-	{
+	if in.Owner != nil {
 		const prefix string = ",\"owner\":"
-		out.RawString(prefix)
-		if in.Owner == nil {
-			out.RawString("null")
+		if first {
+			first = false
+			out.RawString(prefix[1:])
 		} else {
-			out.RawText((*in.Owner).MarshalText())
+			out.RawString(prefix)
 		}
+		(*in.Owner).MarshalEasyJSON(out)
 	}
-	{
+	if len(in.Friends) != 0 {
 		const prefix string = ",\"friends\":"
-		out.RawString(prefix)
-		if in.Friends == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
+		if first {
+			first = false
+			out.RawString(prefix[1:])
 		} else {
-			out.RawByte('[')
-			for v5, v6 := range in.Friends {
-				if v5 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v6))
-			}
-			out.RawByte(']')
+			out.RawString(prefix)
 		}
+		(in.Friends).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PetUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp(w, v)
+func (v PetWithOwnerAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp1(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PetUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp(l, v)
+func (v *PetWithOwnerAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp1(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp1(in *jlexer.Lexer, out *PetCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp2(in *jlexer.Lexer, out *PetViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PetViews, 0, 8)
+			} else {
+				*out = PetViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v4 *PetView
+			if in.IsNull() {
+				in.Skip()
+				v4 = nil
+			} else {
+				if v4 == nil {
+					v4 = new(PetView)
+				}
+				(*v4).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v4)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp2(out *jwriter.Writer, in PetViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v5, v6 := range in {
+			if v5 > 0 {
+				out.RawByte(',')
+			}
+			if v6 == nil {
+				out.RawString("null")
+			} else {
+				(*v6).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp2(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp2(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp3(in *jlexer.Lexer, out *PetView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = string(in.String())
+		case "name":
+			out.Name = string(in.String())
+		case "age":
+			out.Age = int(in.Int())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp3(out *jwriter.Writer, in PetView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != "" {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.ID))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if in.Age != 0 {
+		const prefix string = ",\"age\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.Age))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp3(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp3(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp4(in *jlexer.Lexer, out *PetUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -345,7 +462,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp1(in *jl
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp1(out *jwriter.Writer, in PetCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp4(out *jwriter.Writer, in PetUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -421,224 +538,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp1(out *j
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PetCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp1(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp1(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp2(in *jlexer.Lexer, out *Pet359800019Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Pet359800019Views, 0, 8)
-			} else {
-				*out = Pet359800019Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v13 *Pet359800019View
-			if in.IsNull() {
-				in.Skip()
-				v13 = nil
-			} else {
-				if v13 == nil {
-					v13 = new(Pet359800019View)
-				}
-				(*v13).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v13)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp2(out *jwriter.Writer, in Pet359800019Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v14, v15 := range in {
-			if v14 > 0 {
-				out.RawByte(',')
-			}
-			if v15 == nil {
-				out.RawString("null")
-			} else {
-				(*v15).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet359800019Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp2(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet359800019Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp2(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp3(in *jlexer.Lexer, out *Pet359800019View) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			out.ID = string(in.String())
-		case "name":
-			out.Name = string(in.String())
-		case "age":
-			out.Age = int(in.Int())
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp3(out *jwriter.Writer, in Pet359800019View) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.ID != "" {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.ID))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
-	}
-	if in.Age != 0 {
-		const prefix string = ",\"age\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.Age))
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet359800019View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp3(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet359800019View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp3(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp4(in *jlexer.Lexer, out *Pet1876743790Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Pet1876743790Views, 0, 8)
-			} else {
-				*out = Pet1876743790Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v16 *Pet1876743790View
-			if in.IsNull() {
-				in.Skip()
-				v16 = nil
-			} else {
-				if v16 == nil {
-					v16 = new(Pet1876743790View)
-				}
-				(*v16).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v16)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp4(out *jwriter.Writer, in Pet1876743790Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v17, v18 := range in {
-			if v17 > 0 {
-				out.RawByte(',')
-			}
-			if v18 == nil {
-				out.RawString("null")
-			} else {
-				(*v18).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet1876743790Views) MarshalEasyJSON(w *jwriter.Writer) {
+func (v PetUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp4(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet1876743790Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *PetUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp4(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp5(in *jlexer.Lexer, out *Pet1876743790View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp5(in *jlexer.Lexer, out *PetCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -657,24 +565,94 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp5(in *jl
 			continue
 		}
 		switch key {
-		case "id":
-			out.ID = string(in.String())
 		case "name":
-			out.Name = string(in.String())
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
 		case "age":
-			out.Age = int(in.Int())
+			if in.IsNull() {
+				in.Skip()
+				out.Age = nil
+			} else {
+				if out.Age == nil {
+					out.Age = new(int)
+				}
+				*out.Age = int(in.Int())
+			}
+		case "collar":
+			if in.IsNull() {
+				in.Skip()
+				out.Collar = nil
+			} else {
+				if out.Collar == nil {
+					out.Collar = new(int)
+				}
+				*out.Collar = int(in.Int())
+			}
+		case "categories":
+			if in.IsNull() {
+				in.Skip()
+				out.Categories = nil
+			} else {
+				in.Delim('[')
+				if out.Categories == nil {
+					if !in.IsDelim(']') {
+						out.Categories = make([]uint64, 0, 8)
+					} else {
+						out.Categories = []uint64{}
+					}
+				} else {
+					out.Categories = (out.Categories)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v13 uint64
+					v13 = uint64(in.Uint64())
+					out.Categories = append(out.Categories, v13)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		case "owner":
 			if in.IsNull() {
 				in.Skip()
 				out.Owner = nil
 			} else {
 				if out.Owner == nil {
-					out.Owner = new(Owner139708381View)
+					out.Owner = new(uuid.UUID)
 				}
-				(*out.Owner).UnmarshalEasyJSON(in)
+				if data := in.UnsafeBytes(); in.Ok() {
+					in.AddError((*out.Owner).UnmarshalText(data))
+				}
 			}
 		case "friends":
-			(out.Friends).UnmarshalEasyJSON(in)
+			if in.IsNull() {
+				in.Skip()
+				out.Friends = nil
+			} else {
+				in.Delim('[')
+				if out.Friends == nil {
+					if !in.IsDelim(']') {
+						out.Friends = make([]string, 0, 4)
+					} else {
+						out.Friends = []string{}
+					}
+				} else {
+					out.Friends = (out.Friends)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v14 string
+					v14 = string(in.String())
+					out.Friends = append(out.Friends, v14)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -689,321 +667,91 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp5(in *jl
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp5(out *jwriter.Writer, in Pet1876743790View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp5(out *jwriter.Writer, in PetCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.ID != "" {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.ID))
-	}
-	if in.Name != "" {
+	{
 		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
+			out.String(string(*in.Name))
 		}
-		out.String(string(in.Name))
 	}
-	if in.Age != 0 {
+	{
 		const prefix string = ",\"age\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+		out.RawString(prefix)
+		if in.Age == nil {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
+			out.Int(int(*in.Age))
 		}
-		out.Int(int(in.Age))
 	}
-	if in.Owner != nil {
+	{
+		const prefix string = ",\"collar\":"
+		out.RawString(prefix)
+		if in.Collar == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Collar))
+		}
+	}
+	{
+		const prefix string = ",\"categories\":"
+		out.RawString(prefix)
+		if in.Categories == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v15, v16 := range in.Categories {
+				if v15 > 0 {
+					out.RawByte(',')
+				}
+				out.Uint64(uint64(v16))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
 		const prefix string = ",\"owner\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+		out.RawString(prefix)
+		if in.Owner == nil {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
+			out.RawText((*in.Owner).MarshalText())
 		}
-		(*in.Owner).MarshalEasyJSON(out)
 	}
-	if len(in.Friends) != 0 {
+	{
 		const prefix string = ",\"friends\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+		out.RawString(prefix)
+		if in.Friends == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
+			out.RawByte('[')
+			for v17, v18 := range in.Friends {
+				if v17 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v18))
+			}
+			out.RawByte(']')
 		}
-		(in.Friends).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet1876743790View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v PetCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp5(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet1876743790View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp5(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp6(in *jlexer.Lexer, out *OwnerUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "age":
-			if in.IsNull() {
-				in.Skip()
-				out.Age = nil
-			} else {
-				if out.Age == nil {
-					out.Age = new(int)
-				}
-				*out.Age = int(in.Int())
-			}
-		case "pets":
-			if in.IsNull() {
-				in.Skip()
-				out.Pets = nil
-			} else {
-				in.Delim('[')
-				if out.Pets == nil {
-					if !in.IsDelim(']') {
-						out.Pets = make([]string, 0, 4)
-					} else {
-						out.Pets = []string{}
-					}
-				} else {
-					out.Pets = (out.Pets)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v19 string
-					v19 = string(in.String())
-					out.Pets = append(out.Pets, v19)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp6(out *jwriter.Writer, in OwnerUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"age\":"
-		out.RawString(prefix)
-		if in.Age == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Age))
-		}
-	}
-	{
-		const prefix string = ",\"pets\":"
-		out.RawString(prefix)
-		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v20, v21 := range in.Pets {
-				if v20 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v21))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v OwnerUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp6(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *OwnerUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp6(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp7(in *jlexer.Lexer, out *OwnerCreateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "age":
-			if in.IsNull() {
-				in.Skip()
-				out.Age = nil
-			} else {
-				if out.Age == nil {
-					out.Age = new(int)
-				}
-				*out.Age = int(in.Int())
-			}
-		case "pets":
-			if in.IsNull() {
-				in.Skip()
-				out.Pets = nil
-			} else {
-				in.Delim('[')
-				if out.Pets == nil {
-					if !in.IsDelim(']') {
-						out.Pets = make([]string, 0, 4)
-					} else {
-						out.Pets = []string{}
-					}
-				} else {
-					out.Pets = (out.Pets)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v22 string
-					v22 = string(in.String())
-					out.Pets = append(out.Pets, v22)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp7(out *jwriter.Writer, in OwnerCreateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"age\":"
-		out.RawString(prefix)
-		if in.Age == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Age))
-		}
-	}
-	{
-		const prefix string = ",\"pets\":"
-		out.RawString(prefix)
-		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v23, v24 := range in.Pets {
-				if v23 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v24))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v OwnerCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp7(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *OwnerCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp7(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp8(in *jlexer.Lexer, out *Owner139708381Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp6(in *jlexer.Lexer, out *OwnerWithPetAndPetOwnerViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -1012,25 +760,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp8(in *jl
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Owner139708381Views, 0, 8)
+				*out = make(OwnerWithPetAndPetOwnerViews, 0, 8)
 			} else {
-				*out = Owner139708381Views{}
+				*out = OwnerWithPetAndPetOwnerViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v25 *Owner139708381View
+			var v19 *OwnerWithPetAndPetOwnerView
 			if in.IsNull() {
 				in.Skip()
-				v25 = nil
+				v19 = nil
 			} else {
-				if v25 == nil {
-					v25 = new(Owner139708381View)
+				if v19 == nil {
+					v19 = new(OwnerWithPetAndPetOwnerView)
 				}
-				(*v25).UnmarshalEasyJSON(in)
+				(*v19).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v25)
+			*out = append(*out, v19)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -1039,19 +787,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp8(in *jl
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp8(out *jwriter.Writer, in Owner139708381Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp6(out *jwriter.Writer, in OwnerWithPetAndPetOwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v26, v27 := range in {
-			if v26 > 0 {
+		for v20, v21 := range in {
+			if v20 > 0 {
 				out.RawByte(',')
 			}
-			if v27 == nil {
+			if v21 == nil {
 				out.RawString("null")
 			} else {
-				(*v27).MarshalEasyJSON(out)
+				(*v21).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -1059,15 +807,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp8(out *j
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Owner139708381Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp8(w, v)
+func (v OwnerWithPetAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp6(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Owner139708381Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp8(l, v)
+func (v *OwnerWithPetAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp6(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp9(in *jlexer.Lexer, out *Owner139708381View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp7(in *jlexer.Lexer, out *OwnerWithPetAndPetOwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1108,7 +856,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp9(in *jl
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp9(out *jwriter.Writer, in Owner139708381View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp7(out *jwriter.Writer, in OwnerWithPetAndPetOwnerView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1142,15 +890,414 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp9(out *j
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Owner139708381View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v OwnerWithPetAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp7(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *OwnerWithPetAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp7(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp8(in *jlexer.Lexer, out *OwnerViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(OwnerViews, 0, 8)
+			} else {
+				*out = OwnerViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v22 *OwnerView
+			if in.IsNull() {
+				in.Skip()
+				v22 = nil
+			} else {
+				if v22 == nil {
+					v22 = new(OwnerView)
+				}
+				(*v22).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v22)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp8(out *jwriter.Writer, in OwnerViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v23, v24 := range in {
+			if v23 > 0 {
+				out.RawByte(',')
+			}
+			if v24 == nil {
+				out.RawString("null")
+			} else {
+				(*v24).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v OwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp8(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *OwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp8(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp9(in *jlexer.Lexer, out *OwnerView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.ID).UnmarshalText(data))
+			}
+		case "name":
+			out.Name = string(in.String())
+		case "age":
+			out.Age = int(in.Int())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp9(out *jwriter.Writer, in OwnerView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if true {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.RawText((in.ID).MarshalText())
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if in.Age != 0 {
+		const prefix string = ",\"age\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.Age))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v OwnerView) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp9(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Owner139708381View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *OwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp9(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp10(in *jlexer.Lexer, out *ErrResponse) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp10(in *jlexer.Lexer, out *OwnerUpdateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "age":
+			if in.IsNull() {
+				in.Skip()
+				out.Age = nil
+			} else {
+				if out.Age == nil {
+					out.Age = new(int)
+				}
+				*out.Age = int(in.Int())
+			}
+		case "pets":
+			if in.IsNull() {
+				in.Skip()
+				out.Pets = nil
+			} else {
+				in.Delim('[')
+				if out.Pets == nil {
+					if !in.IsDelim(']') {
+						out.Pets = make([]string, 0, 4)
+					} else {
+						out.Pets = []string{}
+					}
+				} else {
+					out.Pets = (out.Pets)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v25 string
+					v25 = string(in.String())
+					out.Pets = append(out.Pets, v25)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp10(out *jwriter.Writer, in OwnerUpdateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Name))
+		}
+	}
+	{
+		const prefix string = ",\"age\":"
+		out.RawString(prefix)
+		if in.Age == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Age))
+		}
+	}
+	{
+		const prefix string = ",\"pets\":"
+		out.RawString(prefix)
+		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v26, v27 := range in.Pets {
+				if v26 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v27))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v OwnerUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp10(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *OwnerUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp10(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp11(in *jlexer.Lexer, out *OwnerCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "age":
+			if in.IsNull() {
+				in.Skip()
+				out.Age = nil
+			} else {
+				if out.Age == nil {
+					out.Age = new(int)
+				}
+				*out.Age = int(in.Int())
+			}
+		case "pets":
+			if in.IsNull() {
+				in.Skip()
+				out.Pets = nil
+			} else {
+				in.Delim('[')
+				if out.Pets == nil {
+					if !in.IsDelim(']') {
+						out.Pets = make([]string, 0, 4)
+					} else {
+						out.Pets = []string{}
+					}
+				} else {
+					out.Pets = (out.Pets)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v28 string
+					v28 = string(in.String())
+					out.Pets = append(out.Pets, v28)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp11(out *jwriter.Writer, in OwnerCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Name))
+		}
+	}
+	{
+		const prefix string = ",\"age\":"
+		out.RawString(prefix)
+		if in.Age == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Age))
+		}
+	}
+	{
+		const prefix string = ",\"pets\":"
+		out.RawString(prefix)
+		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v29, v30 := range in.Pets {
+				if v29 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v30))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v OwnerCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp11(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *OwnerCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp11(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp12(in *jlexer.Lexer, out *ErrResponse) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1195,7 +1342,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp10(in *j
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp10(out *jwriter.Writer, in ErrResponse) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp12(out *jwriter.Writer, in ErrResponse) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1225,188 +1372,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp10(out *
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ErrResponse) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp10(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *ErrResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp10(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp11(in *jlexer.Lexer, out *CollarUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "color":
-			if in.IsNull() {
-				in.Skip()
-				out.Color = nil
-			} else {
-				if out.Color == nil {
-					out.Color = new(collar.Color)
-				}
-				*out.Color = collar.Color(in.String())
-			}
-		case "pet":
-			if in.IsNull() {
-				in.Skip()
-				out.Pet = nil
-			} else {
-				if out.Pet == nil {
-					out.Pet = new(string)
-				}
-				*out.Pet = string(in.String())
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp11(out *jwriter.Writer, in CollarUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"color\":"
-		out.RawString(prefix[1:])
-		if in.Color == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Color))
-		}
-	}
-	{
-		const prefix string = ",\"pet\":"
-		out.RawString(prefix)
-		if in.Pet == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Pet))
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CollarUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp11(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CollarUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp11(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp12(in *jlexer.Lexer, out *CollarCreateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "color":
-			if in.IsNull() {
-				in.Skip()
-				out.Color = nil
-			} else {
-				if out.Color == nil {
-					out.Color = new(collar.Color)
-				}
-				*out.Color = collar.Color(in.String())
-			}
-		case "pet":
-			if in.IsNull() {
-				in.Skip()
-				out.Pet = nil
-			} else {
-				if out.Pet == nil {
-					out.Pet = new(string)
-				}
-				*out.Pet = string(in.String())
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp12(out *jwriter.Writer, in CollarCreateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"color\":"
-		out.RawString(prefix[1:])
-		if in.Color == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Color))
-		}
-	}
-	{
-		const prefix string = ",\"pet\":"
-		out.RawString(prefix)
-		if in.Pet == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Pet))
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CollarCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp12(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CollarCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *ErrResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp12(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp13(in *jlexer.Lexer, out *Collar1522160880Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp13(in *jlexer.Lexer, out *CollarWithOwnerAndPetAndPetOwnerViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -1415,25 +1388,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp13(in *j
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Collar1522160880Views, 0, 8)
+				*out = make(CollarWithOwnerAndPetAndPetOwnerViews, 0, 8)
 			} else {
-				*out = Collar1522160880Views{}
+				*out = CollarWithOwnerAndPetAndPetOwnerViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v28 *Collar1522160880View
+			var v31 *CollarWithOwnerAndPetAndPetOwnerView
 			if in.IsNull() {
 				in.Skip()
-				v28 = nil
+				v31 = nil
 			} else {
-				if v28 == nil {
-					v28 = new(Collar1522160880View)
+				if v31 == nil {
+					v31 = new(CollarWithOwnerAndPetAndPetOwnerView)
 				}
-				(*v28).UnmarshalEasyJSON(in)
+				(*v31).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v28)
+			*out = append(*out, v31)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -1442,19 +1415,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp13(in *j
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp13(out *jwriter.Writer, in Collar1522160880Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp13(out *jwriter.Writer, in CollarWithOwnerAndPetAndPetOwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v29, v30 := range in {
-			if v29 > 0 {
+		for v32, v33 := range in {
+			if v32 > 0 {
 				out.RawByte(',')
 			}
-			if v30 == nil {
+			if v33 == nil {
 				out.RawString("null")
 			} else {
-				(*v30).MarshalEasyJSON(out)
+				(*v33).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -1462,15 +1435,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp13(out *
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Collar1522160880Views) MarshalEasyJSON(w *jwriter.Writer) {
+func (v CollarWithOwnerAndPetAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp13(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Collar1522160880Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *CollarWithOwnerAndPetAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp13(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp14(in *jlexer.Lexer, out *Collar1522160880View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp14(in *jlexer.Lexer, out *CollarWithOwnerAndPetAndPetOwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1507,7 +1480,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp14(in *j
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp14(out *jwriter.Writer, in Collar1522160880View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp14(out *jwriter.Writer, in CollarWithOwnerAndPetAndPetOwnerView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1531,229 +1504,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp14(out *
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Collar1522160880View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v CollarWithOwnerAndPetAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp14(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Collar1522160880View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *CollarWithOwnerAndPetAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp14(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp15(in *jlexer.Lexer, out *CategoryUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "pets":
-			if in.IsNull() {
-				in.Skip()
-				out.Pets = nil
-			} else {
-				in.Delim('[')
-				if out.Pets == nil {
-					if !in.IsDelim(']') {
-						out.Pets = make([]string, 0, 4)
-					} else {
-						out.Pets = []string{}
-					}
-				} else {
-					out.Pets = (out.Pets)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v31 string
-					v31 = string(in.String())
-					out.Pets = append(out.Pets, v31)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp15(out *jwriter.Writer, in CategoryUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"pets\":"
-		out.RawString(prefix)
-		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v32, v33 := range in.Pets {
-				if v32 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v33))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CategoryUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp15(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CategoryUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp15(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp16(in *jlexer.Lexer, out *CategoryCreateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "pets":
-			if in.IsNull() {
-				in.Skip()
-				out.Pets = nil
-			} else {
-				in.Delim('[')
-				if out.Pets == nil {
-					if !in.IsDelim(']') {
-						out.Pets = make([]string, 0, 4)
-					} else {
-						out.Pets = []string{}
-					}
-				} else {
-					out.Pets = (out.Pets)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v34 string
-					v34 = string(in.String())
-					out.Pets = append(out.Pets, v34)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp16(out *jwriter.Writer, in CategoryCreateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"pets\":"
-		out.RawString(prefix)
-		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v35, v36 := range in.Pets {
-				if v35 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v36))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CategoryCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp16(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CategoryCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp16(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp17(in *jlexer.Lexer, out *Category4094953247Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp15(in *jlexer.Lexer, out *CollarViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -1762,21 +1521,328 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp17(in *j
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Category4094953247Views, 0, 8)
+				*out = make(CollarViews, 0, 8)
 			} else {
-				*out = Category4094953247Views{}
+				*out = CollarViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v37 *Category4094953247View
+			var v34 *CollarView
+			if in.IsNull() {
+				in.Skip()
+				v34 = nil
+			} else {
+				if v34 == nil {
+					v34 = new(CollarView)
+				}
+				(*v34).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v34)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp15(out *jwriter.Writer, in CollarViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v35, v36 := range in {
+			if v35 > 0 {
+				out.RawByte(',')
+			}
+			if v36 == nil {
+				out.RawString("null")
+			} else {
+				(*v36).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp15(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp15(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp16(in *jlexer.Lexer, out *CollarView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "color":
+			out.Color = collar.Color(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp16(out *jwriter.Writer, in CollarView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp16(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp16(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp17(in *jlexer.Lexer, out *CollarUpdateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "color":
+			if in.IsNull() {
+				in.Skip()
+				out.Color = nil
+			} else {
+				if out.Color == nil {
+					out.Color = new(collar.Color)
+				}
+				*out.Color = collar.Color(in.String())
+			}
+		case "pet":
+			if in.IsNull() {
+				in.Skip()
+				out.Pet = nil
+			} else {
+				if out.Pet == nil {
+					out.Pet = new(string)
+				}
+				*out.Pet = string(in.String())
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp17(out *jwriter.Writer, in CollarUpdateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"color\":"
+		out.RawString(prefix[1:])
+		if in.Color == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Color))
+		}
+	}
+	{
+		const prefix string = ",\"pet\":"
+		out.RawString(prefix)
+		if in.Pet == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Pet))
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp17(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp17(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp18(in *jlexer.Lexer, out *CollarCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "color":
+			if in.IsNull() {
+				in.Skip()
+				out.Color = nil
+			} else {
+				if out.Color == nil {
+					out.Color = new(collar.Color)
+				}
+				*out.Color = collar.Color(in.String())
+			}
+		case "pet":
+			if in.IsNull() {
+				in.Skip()
+				out.Pet = nil
+			} else {
+				if out.Pet == nil {
+					out.Pet = new(string)
+				}
+				*out.Pet = string(in.String())
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp18(out *jwriter.Writer, in CollarCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"color\":"
+		out.RawString(prefix[1:])
+		if in.Color == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Color))
+		}
+	}
+	{
+		const prefix string = ",\"pet\":"
+		out.RawString(prefix)
+		if in.Pet == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Pet))
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp18(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp18(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp19(in *jlexer.Lexer, out *CategoryWithOwnerAndPetAndPetOwnerViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(CategoryWithOwnerAndPetAndPetOwnerViews, 0, 8)
+			} else {
+				*out = CategoryWithOwnerAndPetAndPetOwnerViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v37 *CategoryWithOwnerAndPetAndPetOwnerView
 			if in.IsNull() {
 				in.Skip()
 				v37 = nil
 			} else {
 				if v37 == nil {
-					v37 = new(Category4094953247View)
+					v37 = new(CategoryWithOwnerAndPetAndPetOwnerView)
 				}
 				(*v37).UnmarshalEasyJSON(in)
 			}
@@ -1789,7 +1855,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp17(in *j
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp17(out *jwriter.Writer, in Category4094953247Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp19(out *jwriter.Writer, in CategoryWithOwnerAndPetAndPetOwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
@@ -1809,15 +1875,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp17(out *
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Category4094953247Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp17(w, v)
+func (v CategoryWithOwnerAndPetAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp19(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Category4094953247Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp17(l, v)
+func (v *CategoryWithOwnerAndPetAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp19(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp18(in *jlexer.Lexer, out *Category4094953247View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp20(in *jlexer.Lexer, out *CategoryWithOwnerAndPetAndPetOwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1854,7 +1920,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp18(in *j
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp18(out *jwriter.Writer, in Category4094953247View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp20(out *jwriter.Writer, in CategoryWithOwnerAndPetAndPetOwnerView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1878,11 +1944,358 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp18(out *
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Category4094953247View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp18(w, v)
+func (v CategoryWithOwnerAndPetAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp20(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Category4094953247View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp18(l, v)
+func (v *CategoryWithOwnerAndPetAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp20(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp21(in *jlexer.Lexer, out *CategoryViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(CategoryViews, 0, 8)
+			} else {
+				*out = CategoryViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v40 *CategoryView
+			if in.IsNull() {
+				in.Skip()
+				v40 = nil
+			} else {
+				if v40 == nil {
+					v40 = new(CategoryView)
+				}
+				(*v40).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v40)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp21(out *jwriter.Writer, in CategoryViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v41, v42 := range in {
+			if v41 > 0 {
+				out.RawByte(',')
+			}
+			if v42 == nil {
+				out.RawString("null")
+			} else {
+				(*v42).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CategoryViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp21(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CategoryViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp21(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp22(in *jlexer.Lexer, out *CategoryView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = uint64(in.Uint64())
+		case "name":
+			out.Name = string(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp22(out *jwriter.Writer, in CategoryView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Uint64(uint64(in.ID))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CategoryView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp22(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CategoryView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp22(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp23(in *jlexer.Lexer, out *CategoryUpdateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "pets":
+			if in.IsNull() {
+				in.Skip()
+				out.Pets = nil
+			} else {
+				in.Delim('[')
+				if out.Pets == nil {
+					if !in.IsDelim(']') {
+						out.Pets = make([]string, 0, 4)
+					} else {
+						out.Pets = []string{}
+					}
+				} else {
+					out.Pets = (out.Pets)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v43 string
+					v43 = string(in.String())
+					out.Pets = append(out.Pets, v43)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp23(out *jwriter.Writer, in CategoryUpdateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Name))
+		}
+	}
+	{
+		const prefix string = ",\"pets\":"
+		out.RawString(prefix)
+		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v44, v45 := range in.Pets {
+				if v44 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v45))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CategoryUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp23(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CategoryUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp23(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp24(in *jlexer.Lexer, out *CategoryCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "pets":
+			if in.IsNull() {
+				in.Skip()
+				out.Pets = nil
+			} else {
+				in.Delim('[')
+				if out.Pets == nil {
+					if !in.IsDelim(']') {
+						out.Pets = make([]string, 0, 4)
+					} else {
+						out.Pets = []string{}
+					}
+				} else {
+					out.Pets = (out.Pets)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v46 string
+					v46 = string(in.String())
+					out.Pets = append(out.Pets, v46)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp24(out *jwriter.Writer, in CategoryCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Name))
+		}
+	}
+	{
+		const prefix string = ",\"pets\":"
+		out.RawString(prefix)
+		if in.Pets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v47, v48 := range in.Pets {
+				if v47 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v48))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CategoryCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalClientGenEntHttp24(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CategoryCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalClientGenEntHttp24(l, v)
 }

--- a/internal/client_gen/ent/http/list.go
+++ b/internal/client_gen/ent/http/list.go
@@ -41,7 +41,7 @@ func (h *CategoryHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("categories rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryViews(es), w)
 }
 
 // Read fetches the ent.Collar identified by a given url-parameter from the
@@ -75,7 +75,7 @@ func (h *CollarHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collars rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarViews(es), w)
 }
 
 // Read fetches the ent.Owner identified by a given url-parameter from the
@@ -109,7 +109,7 @@ func (h *OwnerHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owners rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerViews(es), w)
 }
 
 // Read fetches the ent.Pet identified by a given url-parameter from the
@@ -143,5 +143,5 @@ func (h *PetHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }

--- a/internal/client_gen/ent/http/read.go
+++ b/internal/client_gen/ent/http/read.go
@@ -49,7 +49,7 @@ func (h *CategoryHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("category rendered", zap.Uint64("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(e), w)
 }
 
 // Read fetches the ent.Collar identified by a given url-parameter from the
@@ -83,7 +83,7 @@ func (h *CollarHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collar rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
 }
 
 // Read fetches the ent.Owner identified by a given url-parameter from the
@@ -117,7 +117,7 @@ func (h *OwnerHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owner rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
 }
 
 // Read fetches the ent.Pet identified by a given url-parameter from the
@@ -155,5 +155,5 @@ func (h *PetHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet1876743790View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetWithOwnerAndPetOwnerView(e), w)
 }

--- a/internal/client_gen/ent/http/relations.go
+++ b/internal/client_gen/ent/http/relations.go
@@ -56,7 +56,7 @@ func (h CategoryHandler) Pets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // Pet fetches the ent.pet attached to the ent.Collar
@@ -98,7 +98,7 @@ func (h CollarHandler) Pet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet1876743790View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetWithOwnerAndPetOwnerView(e), w)
 }
 
 // Pets fetches the ent.pets attached to the ent.Owner
@@ -139,7 +139,7 @@ func (h OwnerHandler) Pets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // Collar fetches the ent.collar attached to the ent.Pet
@@ -169,7 +169,7 @@ func (h PetHandler) Collar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collar rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
 }
 
 // Categories fetches the ent.categories attached to the ent.Pet
@@ -206,7 +206,7 @@ func (h PetHandler) Categories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("categories rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryViews(es), w)
 }
 
 // Owner fetches the ent.owner attached to the ent.Pet
@@ -236,7 +236,7 @@ func (h PetHandler) Owner(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owner rendered", zap.String("id", e.ID.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
 }
 
 // Friends fetches the ent.friends attached to the ent.Pet
@@ -273,5 +273,5 @@ func (h PetHandler) Friends(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }

--- a/internal/client_gen/ent/http/response.go
+++ b/internal/client_gen/ent/http/response.go
@@ -79,169 +79,261 @@ func Unauthorized(w http.ResponseWriter, msg interface{}) (int, error) {
 }
 
 type (
-	// Category4094953247View represents the data serialized for the following serialization group combinations:
+	// CategoryView represents the data serialized for the following serialization group combinations:
 	// []
-	// [owner pet pet:owner]
-	Category4094953247View struct {
+	CategoryView struct {
 		ID   uint64 `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
 	}
-	Category4094953247Views []*Category4094953247View
+	CategoryViews []*CategoryView
 )
 
-func NewCategory4094953247View(e *ent.Category) *Category4094953247View {
+func NewCategoryView(e *ent.Category) *CategoryView {
 	if e == nil {
 		return nil
 	}
-	return &Category4094953247View{
+	return &CategoryView{
 		ID:   e.ID,
 		Name: e.Name,
 	}
 }
 
-func NewCategory4094953247Views(es []*ent.Category) Category4094953247Views {
+func NewCategoryViews(es []*ent.Category) CategoryViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Category4094953247Views, len(es))
+	r := make(CategoryViews, len(es))
 	for i, e := range es {
-		r[i] = NewCategory4094953247View(e)
+		r[i] = NewCategoryView(e)
 	}
 	return r
 }
 
 type (
-	// Collar1522160880View represents the data serialized for the following serialization group combinations:
-	// []
+	// CategoryWithOwnerAndPetAndPetOwnerView represents the data serialized for the following serialization group combinations:
 	// [owner pet pet:owner]
-	Collar1522160880View struct {
-		ID    int          `json:"id,omitempty"`
-		Color collar.Color `json:"color,omitempty"`
+	CategoryWithOwnerAndPetAndPetOwnerView struct {
+		ID   uint64 `json:"id,omitempty"`
+		Name string `json:"name,omitempty"`
 	}
-	Collar1522160880Views []*Collar1522160880View
+	CategoryWithOwnerAndPetAndPetOwnerViews []*CategoryWithOwnerAndPetAndPetOwnerView
 )
 
-func NewCollar1522160880View(e *ent.Collar) *Collar1522160880View {
+func NewCategoryWithOwnerAndPetAndPetOwnerView(e *ent.Category) *CategoryWithOwnerAndPetAndPetOwnerView {
 	if e == nil {
 		return nil
 	}
-	return &Collar1522160880View{
+	return &CategoryWithOwnerAndPetAndPetOwnerView{
+		ID:   e.ID,
+		Name: e.Name,
+	}
+}
+
+func NewCategoryWithOwnerAndPetAndPetOwnerViews(es []*ent.Category) CategoryWithOwnerAndPetAndPetOwnerViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(CategoryWithOwnerAndPetAndPetOwnerViews, len(es))
+	for i, e := range es {
+		r[i] = NewCategoryWithOwnerAndPetAndPetOwnerView(e)
+	}
+	return r
+}
+
+type (
+	// CollarView represents the data serialized for the following serialization group combinations:
+	// []
+	CollarView struct {
+		ID    int          `json:"id,omitempty"`
+		Color collar.Color `json:"color,omitempty"`
+	}
+	CollarViews []*CollarView
+)
+
+func NewCollarView(e *ent.Collar) *CollarView {
+	if e == nil {
+		return nil
+	}
+	return &CollarView{
 		ID:    e.ID,
 		Color: e.Color,
 	}
 }
 
-func NewCollar1522160880Views(es []*ent.Collar) Collar1522160880Views {
+func NewCollarViews(es []*ent.Collar) CollarViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Collar1522160880Views, len(es))
+	r := make(CollarViews, len(es))
 	for i, e := range es {
-		r[i] = NewCollar1522160880View(e)
+		r[i] = NewCollarView(e)
 	}
 	return r
 }
 
 type (
-	// Owner139708381View represents the data serialized for the following serialization group combinations:
-	// []
+	// CollarWithOwnerAndPetAndPetOwnerView represents the data serialized for the following serialization group combinations:
 	// [owner pet pet:owner]
-	Owner139708381View struct {
+	CollarWithOwnerAndPetAndPetOwnerView struct {
+		ID    int          `json:"id,omitempty"`
+		Color collar.Color `json:"color,omitempty"`
+	}
+	CollarWithOwnerAndPetAndPetOwnerViews []*CollarWithOwnerAndPetAndPetOwnerView
+)
+
+func NewCollarWithOwnerAndPetAndPetOwnerView(e *ent.Collar) *CollarWithOwnerAndPetAndPetOwnerView {
+	if e == nil {
+		return nil
+	}
+	return &CollarWithOwnerAndPetAndPetOwnerView{
+		ID:    e.ID,
+		Color: e.Color,
+	}
+}
+
+func NewCollarWithOwnerAndPetAndPetOwnerViews(es []*ent.Collar) CollarWithOwnerAndPetAndPetOwnerViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(CollarWithOwnerAndPetAndPetOwnerViews, len(es))
+	for i, e := range es {
+		r[i] = NewCollarWithOwnerAndPetAndPetOwnerView(e)
+	}
+	return r
+}
+
+type (
+	// OwnerView represents the data serialized for the following serialization group combinations:
+	// []
+	OwnerView struct {
 		ID   uuid.UUID `json:"id,omitempty"`
 		Name string    `json:"name,omitempty"`
 		Age  int       `json:"age,omitempty"`
 	}
-	Owner139708381Views []*Owner139708381View
+	OwnerViews []*OwnerView
 )
 
-func NewOwner139708381View(e *ent.Owner) *Owner139708381View {
+func NewOwnerView(e *ent.Owner) *OwnerView {
 	if e == nil {
 		return nil
 	}
-	return &Owner139708381View{
+	return &OwnerView{
 		ID:   e.ID,
 		Name: e.Name,
 		Age:  e.Age,
 	}
 }
 
-func NewOwner139708381Views(es []*ent.Owner) Owner139708381Views {
+func NewOwnerViews(es []*ent.Owner) OwnerViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Owner139708381Views, len(es))
+	r := make(OwnerViews, len(es))
 	for i, e := range es {
-		r[i] = NewOwner139708381View(e)
+		r[i] = NewOwnerView(e)
 	}
 	return r
 }
 
 type (
-	// Pet1876743790View represents the data serialized for the following serialization group combinations:
+	// OwnerWithPetAndPetOwnerView represents the data serialized for the following serialization group combinations:
 	// [owner pet pet:owner]
-	Pet1876743790View struct {
-		ID      string              `json:"id,omitempty"`
-		Name    string              `json:"name,omitempty"`
-		Age     int                 `json:"age,omitempty"`
-		Owner   *Owner139708381View `json:"owner,omitempty"`
-		Friends Pet359800019Views   `json:"friends,omitempty"`
+	OwnerWithPetAndPetOwnerView struct {
+		ID   uuid.UUID `json:"id,omitempty"`
+		Name string    `json:"name,omitempty"`
+		Age  int       `json:"age,omitempty"`
 	}
-	Pet1876743790Views []*Pet1876743790View
+	OwnerWithPetAndPetOwnerViews []*OwnerWithPetAndPetOwnerView
 )
 
-func NewPet1876743790View(e *ent.Pet) *Pet1876743790View {
+func NewOwnerWithPetAndPetOwnerView(e *ent.Owner) *OwnerWithPetAndPetOwnerView {
 	if e == nil {
 		return nil
 	}
-	return &Pet1876743790View{
-		ID:      e.ID,
-		Name:    e.Name,
-		Age:     e.Age,
-		Owner:   NewOwner139708381View(e.Edges.Owner),
-		Friends: NewPet359800019Views(e.Edges.Friends),
+	return &OwnerWithPetAndPetOwnerView{
+		ID:   e.ID,
+		Name: e.Name,
+		Age:  e.Age,
 	}
 }
 
-func NewPet1876743790Views(es []*ent.Pet) Pet1876743790Views {
+func NewOwnerWithPetAndPetOwnerViews(es []*ent.Owner) OwnerWithPetAndPetOwnerViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Pet1876743790Views, len(es))
+	r := make(OwnerWithPetAndPetOwnerViews, len(es))
 	for i, e := range es {
-		r[i] = NewPet1876743790View(e)
+		r[i] = NewOwnerWithPetAndPetOwnerView(e)
 	}
 	return r
 }
 
 type (
-	// Pet359800019View represents the data serialized for the following serialization group combinations:
+	// PetView represents the data serialized for the following serialization group combinations:
 	// []
-	Pet359800019View struct {
+	PetView struct {
 		ID   string `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
 		Age  int    `json:"age,omitempty"`
 	}
-	Pet359800019Views []*Pet359800019View
+	PetViews []*PetView
 )
 
-func NewPet359800019View(e *ent.Pet) *Pet359800019View {
+func NewPetView(e *ent.Pet) *PetView {
 	if e == nil {
 		return nil
 	}
-	return &Pet359800019View{
+	return &PetView{
 		ID:   e.ID,
 		Name: e.Name,
 		Age:  e.Age,
 	}
 }
 
-func NewPet359800019Views(es []*ent.Pet) Pet359800019Views {
+func NewPetViews(es []*ent.Pet) PetViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Pet359800019Views, len(es))
+	r := make(PetViews, len(es))
 	for i, e := range es {
-		r[i] = NewPet359800019View(e)
+		r[i] = NewPetView(e)
+	}
+	return r
+}
+
+type (
+	// PetWithOwnerAndPetOwnerView represents the data serialized for the following serialization group combinations:
+	// [owner pet pet:owner]
+	PetWithOwnerAndPetOwnerView struct {
+		ID      string                       `json:"id,omitempty"`
+		Name    string                       `json:"name,omitempty"`
+		Age     int                          `json:"age,omitempty"`
+		Owner   *OwnerWithPetAndPetOwnerView `json:"owner,omitempty"`
+		Friends PetWithOwnerAndPetOwnerViews `json:"friends,omitempty"`
+	}
+	PetWithOwnerAndPetOwnerViews []*PetWithOwnerAndPetOwnerView
+)
+
+func NewPetWithOwnerAndPetOwnerView(e *ent.Pet) *PetWithOwnerAndPetOwnerView {
+	if e == nil {
+		return nil
+	}
+	return &PetWithOwnerAndPetOwnerView{
+		ID:      e.ID,
+		Name:    e.Name,
+		Age:     e.Age,
+		Owner:   NewOwnerWithPetAndPetOwnerView(e.Edges.Owner),
+		Friends: NewPetWithOwnerAndPetOwnerViews(e.Edges.Friends),
+	}
+}
+
+func NewPetWithOwnerAndPetOwnerViews(es []*ent.Pet) PetWithOwnerAndPetOwnerViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PetWithOwnerAndPetOwnerViews, len(es))
+	for i, e := range es {
+		r[i] = NewPetWithOwnerAndPetOwnerView(e)
 	}
 	return r
 }

--- a/internal/client_gen/ent/http/update.go
+++ b/internal/client_gen/ent/http/update.go
@@ -81,7 +81,7 @@ func (h CategoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("category rendered", zap.Uint64("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(e), w)
 }
 
 // Update updates a given ent.Collar and saves the changes to the database.
@@ -148,7 +148,7 @@ func (h CollarHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collar rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
 }
 
 // Update updates a given ent.Owner and saves the changes to the database.
@@ -217,7 +217,7 @@ func (h OwnerHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owner rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
 }
 
 // Update updates a given ent.Pet and saves the changes to the database.
@@ -293,5 +293,5 @@ func (h PetHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }

--- a/internal/client_gen/ent/openapi.json
+++ b/internal/client_gen/ent/openapi.json
@@ -46,7 +46,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category4094953247View"
+                    "$ref": "#/components/schemas/CategoryView"
                   }
                 }
               }
@@ -100,7 +100,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -140,7 +140,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -239,7 +239,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -302,7 +302,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -356,7 +356,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Collar1522160880View"
+                    "$ref": "#/components/schemas/CollarView"
                   }
                 }
               }
@@ -408,7 +408,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -448,7 +448,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -545,7 +545,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -587,7 +587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet1876743790View"
+                  "$ref": "#/components/schemas/PetWithOwnerAndPetOwnerView"
                 }
               }
             }
@@ -640,7 +640,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Owner139708381View"
+                    "$ref": "#/components/schemas/OwnerView"
                   }
                 }
               }
@@ -699,7 +699,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -738,7 +738,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -840,7 +840,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -902,7 +902,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -956,7 +956,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -1029,7 +1029,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet359800019View"
+                  "$ref": "#/components/schemas/PetView"
                 }
               }
             }
@@ -1068,7 +1068,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet1876743790View"
+                  "$ref": "#/components/schemas/PetWithOwnerAndPetOwnerView"
                 }
               }
             }
@@ -1184,7 +1184,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet359800019View"
+                  "$ref": "#/components/schemas/PetView"
                 }
               }
             }
@@ -1246,7 +1246,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category4094953247View"
+                    "$ref": "#/components/schemas/CategoryView"
                   }
                 }
               }
@@ -1290,7 +1290,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -1352,7 +1352,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -1395,7 +1395,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -1415,7 +1415,7 @@
   },
   "components": {
     "schemas": {
-      "Category4094953247View": {
+      "CategoryView": {
         "type": "object",
         "required": [
           "id",
@@ -1431,7 +1431,23 @@
           }
         }
       },
-      "Collar1522160880View": {
+      "CategoryWithOwnerAndPetAndPetOwnerView": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "CollarView": {
         "type": "object",
         "required": [
           "color",
@@ -1448,7 +1464,24 @@
           }
         }
       },
-      "Owner139708381View": {
+      "CollarWithOwnerAndPetAndPetOwnerView": {
+        "type": "object",
+        "required": [
+          "color",
+          "id"
+        ],
+        "properties": {
+          "color": {
+            "type": "string",
+            "example": "green"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "OwnerView": {
         "type": "object",
         "required": [
           "age",
@@ -1468,7 +1501,47 @@
           }
         }
       },
-      "Pet1876743790View": {
+      "OwnerWithPetAndPetOwnerView": {
+        "type": "object",
+        "required": [
+          "age",
+          "id",
+          "name"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "PetView": {
+        "type": "object",
+        "required": [
+          "age",
+          "id",
+          "name"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "PetWithOwnerAndPetOwnerView": {
         "type": "object",
         "required": [
           "age",
@@ -1483,7 +1556,7 @@
           "friends": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Pet359800019View"
+              "$ref": "#/components/schemas/PetWithOwnerAndPetOwnerView"
             }
           },
           "id": {
@@ -1493,27 +1566,7 @@
             "type": "string"
           },
           "owner": {
-            "$ref": "#/components/schemas/Owner139708381View"
-          }
-        }
-      },
-      "Pet359800019View": {
-        "type": "object",
-        "required": [
-          "age",
-          "id",
-          "name"
-        ],
-        "properties": {
-          "age": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
+            "$ref": "#/components/schemas/OwnerWithPetAndPetOwnerView"
           }
         }
       }

--- a/internal/client_gen/ent/stub/http.go
+++ b/internal/client_gen/ent/stub/http.go
@@ -17,39 +17,46 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 )
 
-// Category4094953247View defines model for Category4094953247View.
-type Category4094953247View struct {
+// CategoryView defines model for CategoryView.
+type CategoryView struct {
 	Id   int64  `json:"id"`
 	Name string `json:"name"`
 }
 
-// Collar1522160880View defines model for Collar1522160880View.
-type Collar1522160880View struct {
+// CollarView defines model for CollarView.
+type CollarView struct {
 	Color string `json:"color"`
 	Id    int32  `json:"id"`
 }
 
-// Owner139708381View defines model for Owner139708381View.
-type Owner139708381View struct {
+// OwnerView defines model for OwnerView.
+type OwnerView struct {
 	Age  int32  `json:"age"`
 	Id   string `json:"id"`
 	Name string `json:"name"`
 }
 
-// Pet1876743790View defines model for Pet1876743790View.
-type Pet1876743790View struct {
-	Age     int32               `json:"age"`
-	Friends *[]Pet359800019View `json:"friends,omitempty"`
-	Id      string              `json:"id"`
-	Name    string              `json:"name"`
-	Owner   *Owner139708381View `json:"owner,omitempty"`
-}
-
-// Pet359800019View defines model for Pet359800019View.
-type Pet359800019View struct {
+// OwnerWithPetAndPetOwnerView defines model for OwnerWithPetAndPetOwnerView.
+type OwnerWithPetAndPetOwnerView struct {
 	Age  int32  `json:"age"`
 	Id   string `json:"id"`
 	Name string `json:"name"`
+}
+
+// PetView defines model for PetView.
+type PetView struct {
+	Age  int32  `json:"age"`
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// PetWithOwnerAndPetOwnerView defines model for PetWithOwnerAndPetOwnerView.
+type PetWithOwnerAndPetOwnerView struct {
+	Age     int32                          `json:"age"`
+	Friends *[]PetWithOwnerAndPetOwnerView `json:"friends,omitempty"`
+	Id      string                         `json:"id"`
+	Name    string                         `json:"name"`
+	Owner   *OwnerWithPetAndPetOwnerView   `json:"owner,omitempty"`
 }
 
 // N400 defines model for 400.
@@ -2216,7 +2223,7 @@ type ClientWithResponsesInterface interface {
 type ListCategoryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Category4094953247View
+	JSON200      *[]CategoryView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2253,7 +2260,7 @@ func (r ListCategoryResponse) StatusCode() int {
 type CreateCategoryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Category4094953247View
+	JSON200      *CategoryView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2321,7 +2328,7 @@ func (r DeleteCategoryResponse) StatusCode() int {
 type ReadCategoryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Category4094953247View
+	JSON200      *CategoryView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2358,7 +2365,7 @@ func (r ReadCategoryResponse) StatusCode() int {
 type UpdateCategoryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Category4094953247View
+	JSON200      *CategoryView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2395,7 +2402,7 @@ func (r UpdateCategoryResponse) StatusCode() int {
 type ListCategoryPetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Pet359800019View
+	JSON200      *[]PetView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2432,7 +2439,7 @@ func (r ListCategoryPetsResponse) StatusCode() int {
 type ListCollarResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Collar1522160880View
+	JSON200      *[]CollarView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2469,7 +2476,7 @@ func (r ListCollarResponse) StatusCode() int {
 type CreateCollarResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Collar1522160880View
+	JSON200      *CollarView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2537,7 +2544,7 @@ func (r DeleteCollarResponse) StatusCode() int {
 type ReadCollarResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Collar1522160880View
+	JSON200      *CollarView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2574,7 +2581,7 @@ func (r ReadCollarResponse) StatusCode() int {
 type UpdateCollarResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Collar1522160880View
+	JSON200      *CollarView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2611,7 +2618,7 @@ func (r UpdateCollarResponse) StatusCode() int {
 type ReadCollarPetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Pet1876743790View
+	JSON200      *PetWithOwnerAndPetOwnerView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2648,7 +2655,7 @@ func (r ReadCollarPetResponse) StatusCode() int {
 type ListOwnerResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Owner139708381View
+	JSON200      *[]OwnerView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2685,7 +2692,7 @@ func (r ListOwnerResponse) StatusCode() int {
 type CreateOwnerResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Owner139708381View
+	JSON200      *OwnerView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2753,7 +2760,7 @@ func (r DeleteOwnerResponse) StatusCode() int {
 type ReadOwnerResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Owner139708381View
+	JSON200      *OwnerView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2790,7 +2797,7 @@ func (r ReadOwnerResponse) StatusCode() int {
 type UpdateOwnerResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Owner139708381View
+	JSON200      *OwnerView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2827,7 +2834,7 @@ func (r UpdateOwnerResponse) StatusCode() int {
 type ListOwnerPetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Pet359800019View
+	JSON200      *[]PetView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2864,7 +2871,7 @@ func (r ListOwnerPetsResponse) StatusCode() int {
 type ListPetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Pet359800019View
+	JSON200      *[]PetView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2901,7 +2908,7 @@ func (r ListPetResponse) StatusCode() int {
 type CreatePetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Pet359800019View
+	JSON200      *PetView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -2969,7 +2976,7 @@ func (r DeletePetResponse) StatusCode() int {
 type ReadPetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Pet1876743790View
+	JSON200      *PetWithOwnerAndPetOwnerView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -3006,7 +3013,7 @@ func (r ReadPetResponse) StatusCode() int {
 type UpdatePetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Pet359800019View
+	JSON200      *PetView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -3043,7 +3050,7 @@ func (r UpdatePetResponse) StatusCode() int {
 type ListPetCategoriesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Category4094953247View
+	JSON200      *[]CategoryView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -3080,7 +3087,7 @@ func (r ListPetCategoriesResponse) StatusCode() int {
 type ReadPetCollarResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Collar1522160880View
+	JSON200      *CollarView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -3117,7 +3124,7 @@ func (r ReadPetCollarResponse) StatusCode() int {
 type ListPetFriendsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]Pet359800019View
+	JSON200      *[]PetView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -3154,7 +3161,7 @@ func (r ListPetFriendsResponse) StatusCode() int {
 type ReadPetOwnerResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *Owner139708381View
+	JSON200      *OwnerView
 	JSON400      *struct {
 		Code   *int32                  `json:"code,omitempty"`
 		Errors *map[string]interface{} `json:"errors,omitempty"`
@@ -3510,7 +3517,7 @@ func ParseListCategoryResponse(rsp *http.Response) (*ListCategoryResponse, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Category4094953247View
+		var dest []CategoryView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3569,7 +3576,7 @@ func ParseCreateCategoryResponse(rsp *http.Response) (*CreateCategoryResponse, e
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Category4094953247View
+		var dest CategoryView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3669,7 +3676,7 @@ func ParseReadCategoryResponse(rsp *http.Response) (*ReadCategoryResponse, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Category4094953247View
+		var dest CategoryView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3728,7 +3735,7 @@ func ParseUpdateCategoryResponse(rsp *http.Response) (*UpdateCategoryResponse, e
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Category4094953247View
+		var dest CategoryView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3787,7 +3794,7 @@ func ParseListCategoryPetsResponse(rsp *http.Response) (*ListCategoryPetsRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Pet359800019View
+		var dest []PetView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3846,7 +3853,7 @@ func ParseListCollarResponse(rsp *http.Response) (*ListCollarResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Collar1522160880View
+		var dest []CollarView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3905,7 +3912,7 @@ func ParseCreateCollarResponse(rsp *http.Response) (*CreateCollarResponse, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Collar1522160880View
+		var dest CollarView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4005,7 +4012,7 @@ func ParseReadCollarResponse(rsp *http.Response) (*ReadCollarResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Collar1522160880View
+		var dest CollarView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4064,7 +4071,7 @@ func ParseUpdateCollarResponse(rsp *http.Response) (*UpdateCollarResponse, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Collar1522160880View
+		var dest CollarView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4123,7 +4130,7 @@ func ParseReadCollarPetResponse(rsp *http.Response) (*ReadCollarPetResponse, err
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Pet1876743790View
+		var dest PetWithOwnerAndPetOwnerView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4182,7 +4189,7 @@ func ParseListOwnerResponse(rsp *http.Response) (*ListOwnerResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Owner139708381View
+		var dest []OwnerView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4241,7 +4248,7 @@ func ParseCreateOwnerResponse(rsp *http.Response) (*CreateOwnerResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Owner139708381View
+		var dest OwnerView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4341,7 +4348,7 @@ func ParseReadOwnerResponse(rsp *http.Response) (*ReadOwnerResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Owner139708381View
+		var dest OwnerView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4400,7 +4407,7 @@ func ParseUpdateOwnerResponse(rsp *http.Response) (*UpdateOwnerResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Owner139708381View
+		var dest OwnerView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4459,7 +4466,7 @@ func ParseListOwnerPetsResponse(rsp *http.Response) (*ListOwnerPetsResponse, err
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Pet359800019View
+		var dest []PetView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4518,7 +4525,7 @@ func ParseListPetResponse(rsp *http.Response) (*ListPetResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Pet359800019View
+		var dest []PetView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4577,7 +4584,7 @@ func ParseCreatePetResponse(rsp *http.Response) (*CreatePetResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Pet359800019View
+		var dest PetView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4677,7 +4684,7 @@ func ParseReadPetResponse(rsp *http.Response) (*ReadPetResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Pet1876743790View
+		var dest PetWithOwnerAndPetOwnerView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4736,7 +4743,7 @@ func ParseUpdatePetResponse(rsp *http.Response) (*UpdatePetResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Pet359800019View
+		var dest PetView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4795,7 +4802,7 @@ func ParseListPetCategoriesResponse(rsp *http.Response) (*ListPetCategoriesRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Category4094953247View
+		var dest []CategoryView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4854,7 +4861,7 @@ func ParseReadPetCollarResponse(rsp *http.Response) (*ReadPetCollarResponse, err
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Collar1522160880View
+		var dest CollarView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4913,7 +4920,7 @@ func ParseListPetFriendsResponse(rsp *http.Response) (*ListPetFriendsResponse, e
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Pet359800019View
+		var dest []PetView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4972,7 +4979,7 @@ func ParseReadPetOwnerResponse(rsp *http.Response) (*ReadPetOwnerResponse, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Owner139708381View
+		var dest OwnerView
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/fridge/ent/http/create.go
+++ b/internal/fridge/ent/http/create.go
@@ -43,27 +43,29 @@ func (h CompartmentHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Compartment.Query().Where(compartment.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Int("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Int("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read compartment", zap.Error(err), zap.Int("id", e.ID))
+			l.Error("could not read compartment", zap.Error(err), zap.Int("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("compartment rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewCompartmentView(e), w)
+	l.Info("compartment rendered", zap.Int("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewCompartmentView(ret), w)
 }
 
 // Create creates a new ent.Fridge and stores it in the database.
@@ -93,27 +95,29 @@ func (h FridgeHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Fridge.Query().Where(fridge.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Int("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Int("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read fridge", zap.Error(err), zap.Int("id", e.ID))
+			l.Error("could not read fridge", zap.Error(err), zap.Int("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("fridge rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewFridgeView(e), w)
+	l.Info("fridge rendered", zap.Int("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewFridgeView(ret), w)
 }
 
 // Create creates a new ent.Item and stores it in the database.
@@ -143,25 +147,27 @@ func (h ItemHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Item.Query().Where(item.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Int("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Int("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read item", zap.Error(err), zap.Int("id", e.ID))
+			l.Error("could not read item", zap.Error(err), zap.Int("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("item rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewItemView(e), w)
+	l.Info("item rendered", zap.Int("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewItemView(ret), w)
 }

--- a/internal/fridge/ent/http/create.go
+++ b/internal/fridge/ent/http/create.go
@@ -43,29 +43,27 @@ func (h CompartmentHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Compartment.Query().Where(compartment.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", id))
+			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", id))
+			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read compartment", zap.Error(err), zap.Int("id", id))
+			l.Error("could not read compartment", zap.Error(err), zap.Int("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("compartment rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCompartment1151786357View(ret), w)
+	l.Info("compartment rendered", zap.Int("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewCompartmentView(e), w)
 }
 
 // Create creates a new ent.Fridge and stores it in the database.
@@ -95,29 +93,27 @@ func (h FridgeHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Fridge.Query().Where(fridge.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", id))
+			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", id))
+			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read fridge", zap.Error(err), zap.Int("id", id))
+			l.Error("could not read fridge", zap.Error(err), zap.Int("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("fridge rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewFridge2716213877View(ret), w)
+	l.Info("fridge rendered", zap.Int("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewFridgeView(e), w)
 }
 
 // Create creates a new ent.Item and stores it in the database.
@@ -147,27 +143,25 @@ func (h ItemHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Item.Query().Where(item.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", id))
+			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", id))
+			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read item", zap.Error(err), zap.Int("id", id))
+			l.Error("could not read item", zap.Error(err), zap.Int("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("item rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewItem1509516544View(ret), w)
+	l.Info("item rendered", zap.Int("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewItemView(e), w)
 }

--- a/internal/fridge/ent/http/easyjson.go
+++ b/internal/fridge/ent/http/easyjson.go
@@ -17,181 +17,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp(in *jlexer.Lexer, out *ItemUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "compartment":
-			if in.IsNull() {
-				in.Skip()
-				out.Compartment = nil
-			} else {
-				if out.Compartment == nil {
-					out.Compartment = new(int)
-				}
-				*out.Compartment = int(in.Int())
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp(out *jwriter.Writer, in ItemUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"compartment\":"
-		out.RawString(prefix)
-		if in.Compartment == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Compartment))
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ItemUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *ItemUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp1(in *jlexer.Lexer, out *ItemCreateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "compartment":
-			if in.IsNull() {
-				in.Skip()
-				out.Compartment = nil
-			} else {
-				if out.Compartment == nil {
-					out.Compartment = new(int)
-				}
-				*out.Compartment = int(in.Int())
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp1(out *jwriter.Writer, in ItemCreateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"compartment\":"
-		out.RawString(prefix)
-		if in.Compartment == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Compartment))
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ItemCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp1(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *ItemCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp1(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp2(in *jlexer.Lexer, out *Item1509516544Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp(in *jlexer.Lexer, out *ItemViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -200,21 +26,21 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp2(in *jlexe
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Item1509516544Views, 0, 8)
+				*out = make(ItemViews, 0, 8)
 			} else {
-				*out = Item1509516544Views{}
+				*out = ItemViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v1 *Item1509516544View
+			var v1 *ItemView
 			if in.IsNull() {
 				in.Skip()
 				v1 = nil
 			} else {
 				if v1 == nil {
-					v1 = new(Item1509516544View)
+					v1 = new(ItemView)
 				}
 				(*v1).UnmarshalEasyJSON(in)
 			}
@@ -227,7 +53,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp2(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp2(out *jwriter.Writer, in Item1509516544Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp(out *jwriter.Writer, in ItemViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
@@ -247,15 +73,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp2(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Item1509516544Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp2(w, v)
+func (v ItemViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Item1509516544Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp2(l, v)
+func (v *ItemViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp3(in *jlexer.Lexer, out *Item1509516544View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp1(in *jlexer.Lexer, out *ItemView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -292,7 +118,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp3(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp3(out *jwriter.Writer, in Item1509516544View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp1(out *jwriter.Writer, in ItemView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -316,15 +142,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp3(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Item1509516544View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp3(w, v)
+func (v ItemView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp1(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Item1509516544View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp3(l, v)
+func (v *ItemView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp1(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp4(in *jlexer.Lexer, out *FridgeUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp2(in *jlexer.Lexer, out *ItemUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -343,38 +169,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp4(in *jlexe
 			continue
 		}
 		switch key {
-		case "title":
+		case "name":
 			if in.IsNull() {
 				in.Skip()
-				out.Title = nil
+				out.Name = nil
 			} else {
-				if out.Title == nil {
-					out.Title = new(string)
+				if out.Name == nil {
+					out.Name = new(string)
 				}
-				*out.Title = string(in.String())
+				*out.Name = string(in.String())
 			}
-		case "compartments":
+		case "compartment":
 			if in.IsNull() {
 				in.Skip()
-				out.Compartments = nil
+				out.Compartment = nil
 			} else {
-				in.Delim('[')
-				if out.Compartments == nil {
-					if !in.IsDelim(']') {
-						out.Compartments = make([]int, 0, 8)
-					} else {
-						out.Compartments = []int{}
-					}
-				} else {
-					out.Compartments = (out.Compartments)[:0]
+				if out.Compartment == nil {
+					out.Compartment = new(int)
 				}
-				for !in.IsDelim(']') {
-					var v4 int
-					v4 = int(in.Int())
-					out.Compartments = append(out.Compartments, v4)
-					in.WantComma()
-				}
-				in.Delim(']')
+				*out.Compartment = int(in.Int())
 			}
 		default:
 			in.AddError(&jlexer.LexerError{
@@ -390,48 +203,261 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp4(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp4(out *jwriter.Writer, in FridgeUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp2(out *jwriter.Writer, in ItemUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
 	{
-		const prefix string = ",\"title\":"
+		const prefix string = ",\"name\":"
 		out.RawString(prefix[1:])
-		if in.Title == nil {
+		if in.Name == nil {
 			out.RawString("null")
 		} else {
-			out.String(string(*in.Title))
+			out.String(string(*in.Name))
 		}
 	}
 	{
-		const prefix string = ",\"compartments\":"
+		const prefix string = ",\"compartment\":"
 		out.RawString(prefix)
-		if in.Compartments == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		if in.Compartment == nil {
 			out.RawString("null")
 		} else {
-			out.RawByte('[')
-			for v5, v6 := range in.Compartments {
-				if v5 > 0 {
-					out.RawByte(',')
-				}
-				out.Int(int(v6))
-			}
-			out.RawByte(']')
+			out.Int(int(*in.Compartment))
 		}
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FridgeUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ItemUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp2(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ItemUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp2(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp3(in *jlexer.Lexer, out *ItemCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "compartment":
+			if in.IsNull() {
+				in.Skip()
+				out.Compartment = nil
+			} else {
+				if out.Compartment == nil {
+					out.Compartment = new(int)
+				}
+				*out.Compartment = int(in.Int())
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp3(out *jwriter.Writer, in ItemCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Name))
+		}
+	}
+	{
+		const prefix string = ",\"compartment\":"
+		out.RawString(prefix)
+		if in.Compartment == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Compartment))
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ItemCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp3(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ItemCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp3(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp4(in *jlexer.Lexer, out *FridgeViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(FridgeViews, 0, 8)
+			} else {
+				*out = FridgeViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v4 *FridgeView
+			if in.IsNull() {
+				in.Skip()
+				v4 = nil
+			} else {
+				if v4 == nil {
+					v4 = new(FridgeView)
+				}
+				(*v4).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v4)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp4(out *jwriter.Writer, in FridgeViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v5, v6 := range in {
+			if v5 > 0 {
+				out.RawByte(',')
+			}
+			if v6 == nil {
+				out.RawString("null")
+			} else {
+				(*v6).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v FridgeViews) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp4(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FridgeUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *FridgeViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp4(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp5(in *jlexer.Lexer, out *FridgeCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp5(in *jlexer.Lexer, out *FridgeView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "title":
+			out.Title = string(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp5(out *jwriter.Writer, in FridgeView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v FridgeView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp5(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *FridgeView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp5(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp6(in *jlexer.Lexer, out *FridgeUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -497,7 +523,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp5(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp5(out *jwriter.Writer, in FridgeCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp6(out *jwriter.Writer, in FridgeUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -530,79 +556,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp5(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v FridgeCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp5(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *FridgeCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp5(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp6(in *jlexer.Lexer, out *Fridge2716213877Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Fridge2716213877Views, 0, 8)
-			} else {
-				*out = Fridge2716213877Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v10 *Fridge2716213877View
-			if in.IsNull() {
-				in.Skip()
-				v10 = nil
-			} else {
-				if v10 == nil {
-					v10 = new(Fridge2716213877View)
-				}
-				(*v10).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v10)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp6(out *jwriter.Writer, in Fridge2716213877Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v11, v12 := range in {
-			if v11 > 0 {
-				out.RawByte(',')
-			}
-			if v12 == nil {
-				out.RawString("null")
-			} else {
-				(*v12).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Fridge2716213877Views) MarshalEasyJSON(w *jwriter.Writer) {
+func (v FridgeUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp6(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Fridge2716213877Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *FridgeUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp6(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp7(in *jlexer.Lexer, out *Fridge2716213877View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp7(in *jlexer.Lexer, out *FridgeCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -621,10 +583,39 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp7(in *jlexe
 			continue
 		}
 		switch key {
-		case "id":
-			out.ID = int(in.Int())
 		case "title":
-			out.Title = string(in.String())
+			if in.IsNull() {
+				in.Skip()
+				out.Title = nil
+			} else {
+				if out.Title == nil {
+					out.Title = new(string)
+				}
+				*out.Title = string(in.String())
+			}
+		case "compartments":
+			if in.IsNull() {
+				in.Skip()
+				out.Compartments = nil
+			} else {
+				in.Delim('[')
+				if out.Compartments == nil {
+					if !in.IsDelim(']') {
+						out.Compartments = make([]int, 0, 8)
+					} else {
+						out.Compartments = []int{}
+					}
+				} else {
+					out.Compartments = (out.Compartments)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v10 int
+					v10 = int(in.Int())
+					out.Compartments = append(out.Compartments, v10)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -639,36 +630,45 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp7(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp7(out *jwriter.Writer, in Fridge2716213877View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp7(out *jwriter.Writer, in FridgeCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.ID != 0 {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Int(int(in.ID))
-	}
-	if in.Title != "" {
+	{
 		const prefix string = ",\"title\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+		out.RawString(prefix[1:])
+		if in.Title == nil {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
+			out.String(string(*in.Title))
 		}
-		out.String(string(in.Title))
+	}
+	{
+		const prefix string = ",\"compartments\":"
+		out.RawString(prefix)
+		if in.Compartments == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v11, v12 := range in.Compartments {
+				if v11 > 0 {
+					out.RawByte(',')
+				}
+				out.Int(int(v12))
+			}
+			out.RawByte(']')
+		}
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Fridge2716213877View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v FridgeCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp7(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Fridge2716213877View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *FridgeCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp7(l, v)
 }
 func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp8(in *jlexer.Lexer, out *ErrResponse) {
@@ -753,7 +753,71 @@ func (v ErrResponse) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *ErrResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp8(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp9(in *jlexer.Lexer, out *CompartmentUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp9(in *jlexer.Lexer, out *CompartmentViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(CompartmentViews, 0, 8)
+			} else {
+				*out = CompartmentViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v13 *CompartmentView
+			if in.IsNull() {
+				in.Skip()
+				v13 = nil
+			} else {
+				if v13 == nil {
+					v13 = new(CompartmentView)
+				}
+				(*v13).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v13)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp9(out *jwriter.Writer, in CompartmentViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v14, v15 := range in {
+			if v14 > 0 {
+				out.RawByte(',')
+			}
+			if v15 == nil {
+				out.RawString("null")
+			} else {
+				(*v15).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CompartmentViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp9(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CompartmentViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp9(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp10(in *jlexer.Lexer, out *CompartmentView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -772,49 +836,10 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp9(in *jlexe
 			continue
 		}
 		switch key {
+		case "id":
+			out.ID = int(in.Int())
 		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "fridge":
-			if in.IsNull() {
-				in.Skip()
-				out.Fridge = nil
-			} else {
-				if out.Fridge == nil {
-					out.Fridge = new(int)
-				}
-				*out.Fridge = int(in.Int())
-			}
-		case "contents":
-			if in.IsNull() {
-				in.Skip()
-				out.Contents = nil
-			} else {
-				in.Delim('[')
-				if out.Contents == nil {
-					if !in.IsDelim(']') {
-						out.Contents = make([]int, 0, 8)
-					} else {
-						out.Contents = []int{}
-					}
-				} else {
-					out.Contents = (out.Contents)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v13 int
-					v13 = int(in.Int())
-					out.Contents = append(out.Contents, v13)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
+			out.Name = string(in.String())
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -829,57 +854,39 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp9(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp9(out *jwriter.Writer, in CompartmentUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp10(out *jwriter.Writer, in CompartmentView) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	{
-		const prefix string = ",\"name\":"
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
 		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
+		out.Int(int(in.ID))
 	}
-	{
-		const prefix string = ",\"fridge\":"
-		out.RawString(prefix)
-		if in.Fridge == nil {
-			out.RawString("null")
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
 		} else {
-			out.Int(int(*in.Fridge))
+			out.RawString(prefix)
 		}
-	}
-	{
-		const prefix string = ",\"contents\":"
-		out.RawString(prefix)
-		if in.Contents == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v14, v15 := range in.Contents {
-				if v14 > 0 {
-					out.RawByte(',')
-				}
-				out.Int(int(v15))
-			}
-			out.RawByte(']')
-		}
+		out.String(string(in.Name))
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CompartmentUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp9(w, v)
+func (v CompartmentView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp10(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CompartmentUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp9(l, v)
+func (v *CompartmentView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp10(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp10(in *jlexer.Lexer, out *CompartmentCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp11(in *jlexer.Lexer, out *CompartmentUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -955,7 +962,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp10(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp10(out *jwriter.Writer, in CompartmentCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp11(out *jwriter.Writer, in CompartmentUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -997,79 +1004,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp10(out *jwr
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CompartmentCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp10(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CompartmentCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp10(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp11(in *jlexer.Lexer, out *Compartment1151786357Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Compartment1151786357Views, 0, 8)
-			} else {
-				*out = Compartment1151786357Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v19 *Compartment1151786357View
-			if in.IsNull() {
-				in.Skip()
-				v19 = nil
-			} else {
-				if v19 == nil {
-					v19 = new(Compartment1151786357View)
-				}
-				(*v19).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v19)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp11(out *jwriter.Writer, in Compartment1151786357Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v20, v21 := range in {
-			if v20 > 0 {
-				out.RawByte(',')
-			}
-			if v21 == nil {
-				out.RawString("null")
-			} else {
-				(*v21).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Compartment1151786357Views) MarshalEasyJSON(w *jwriter.Writer) {
+func (v CompartmentUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp11(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Compartment1151786357Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *CompartmentUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp11(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp12(in *jlexer.Lexer, out *Compartment1151786357View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp12(in *jlexer.Lexer, out *CompartmentCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1088,10 +1031,49 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp12(in *jlex
 			continue
 		}
 		switch key {
-		case "id":
-			out.ID = int(in.Int())
 		case "name":
-			out.Name = string(in.String())
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "fridge":
+			if in.IsNull() {
+				in.Skip()
+				out.Fridge = nil
+			} else {
+				if out.Fridge == nil {
+					out.Fridge = new(int)
+				}
+				*out.Fridge = int(in.Int())
+			}
+		case "contents":
+			if in.IsNull() {
+				in.Skip()
+				out.Contents = nil
+			} else {
+				in.Delim('[')
+				if out.Contents == nil {
+					if !in.IsDelim(']') {
+						out.Contents = make([]int, 0, 8)
+					} else {
+						out.Contents = []int{}
+					}
+				} else {
+					out.Contents = (out.Contents)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v19 int
+					v19 = int(in.Int())
+					out.Contents = append(out.Contents, v19)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -1106,35 +1088,53 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp12(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp12(out *jwriter.Writer, in Compartment1151786357View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp12(out *jwriter.Writer, in CompartmentCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.ID != 0 {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Int(int(in.ID))
-	}
-	if in.Name != "" {
+	{
 		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
+			out.String(string(*in.Name))
 		}
-		out.String(string(in.Name))
+	}
+	{
+		const prefix string = ",\"fridge\":"
+		out.RawString(prefix)
+		if in.Fridge == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Fridge))
+		}
+	}
+	{
+		const prefix string = ",\"contents\":"
+		out.RawString(prefix)
+		if in.Contents == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v20, v21 := range in.Contents {
+				if v20 > 0 {
+					out.RawByte(',')
+				}
+				out.Int(int(v21))
+			}
+			out.RawByte(']')
+		}
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Compartment1151786357View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v CompartmentCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalFridgeEntHttp12(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Compartment1151786357View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *CompartmentCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalFridgeEntHttp12(l, v)
 }

--- a/internal/fridge/ent/http/list.go
+++ b/internal/fridge/ent/http/list.go
@@ -41,7 +41,7 @@ func (h *CompartmentHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("compartments rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCompartment1151786357Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCompartmentViews(es), w)
 }
 
 // Read fetches the ent.Fridge identified by a given url-parameter from the
@@ -75,7 +75,7 @@ func (h *FridgeHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("fridges rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewFridge2716213877Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewFridgeViews(es), w)
 }
 
 // Read fetches the ent.Item identified by a given url-parameter from the
@@ -109,5 +109,5 @@ func (h *ItemHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("items rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewItem1509516544Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewItemViews(es), w)
 }

--- a/internal/fridge/ent/http/read.go
+++ b/internal/fridge/ent/http/read.go
@@ -46,7 +46,7 @@ func (h *CompartmentHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("compartment rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCompartment1151786357View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCompartmentView(e), w)
 }
 
 // Read fetches the ent.Fridge identified by a given url-parameter from the
@@ -80,7 +80,7 @@ func (h *FridgeHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("fridge rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewFridge2716213877View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewFridgeView(e), w)
 }
 
 // Read fetches the ent.Item identified by a given url-parameter from the
@@ -114,5 +114,5 @@ func (h *ItemHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("item rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewItem1509516544View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewItemView(e), w)
 }

--- a/internal/fridge/ent/http/relations.go
+++ b/internal/fridge/ent/http/relations.go
@@ -46,7 +46,7 @@ func (h CompartmentHandler) Fridge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("fridge rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewFridge2716213877View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewFridgeView(e), w)
 }
 
 // Contents fetches the ent.contents attached to the ent.Compartment
@@ -87,7 +87,7 @@ func (h CompartmentHandler) Contents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("items rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewItem1509516544Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewItemViews(es), w)
 }
 
 // Compartments fetches the ent.compartments attached to the ent.Fridge
@@ -128,7 +128,7 @@ func (h FridgeHandler) Compartments(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("compartments rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCompartment1151786357Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCompartmentViews(es), w)
 }
 
 // Compartment fetches the ent.compartment attached to the ent.Item
@@ -162,5 +162,5 @@ func (h ItemHandler) Compartment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("compartment rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewCompartment1151786357View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCompartmentView(e), w)
 }

--- a/internal/fridge/ent/http/response.go
+++ b/internal/fridge/ent/http/response.go
@@ -77,94 +77,94 @@ func Unauthorized(w http.ResponseWriter, msg interface{}) (int, error) {
 }
 
 type (
-	// Compartment1151786357View represents the data serialized for the following serialization group combinations:
+	// CompartmentView represents the data serialized for the following serialization group combinations:
 	// []
-	Compartment1151786357View struct {
+	CompartmentView struct {
 		ID   int    `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
 	}
-	Compartment1151786357Views []*Compartment1151786357View
+	CompartmentViews []*CompartmentView
 )
 
-func NewCompartment1151786357View(e *ent.Compartment) *Compartment1151786357View {
+func NewCompartmentView(e *ent.Compartment) *CompartmentView {
 	if e == nil {
 		return nil
 	}
-	return &Compartment1151786357View{
+	return &CompartmentView{
 		ID:   e.ID,
 		Name: e.Name,
 	}
 }
 
-func NewCompartment1151786357Views(es []*ent.Compartment) Compartment1151786357Views {
+func NewCompartmentViews(es []*ent.Compartment) CompartmentViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Compartment1151786357Views, len(es))
+	r := make(CompartmentViews, len(es))
 	for i, e := range es {
-		r[i] = NewCompartment1151786357View(e)
+		r[i] = NewCompartmentView(e)
 	}
 	return r
 }
 
 type (
-	// Fridge2716213877View represents the data serialized for the following serialization group combinations:
+	// FridgeView represents the data serialized for the following serialization group combinations:
 	// []
-	Fridge2716213877View struct {
+	FridgeView struct {
 		ID    int    `json:"id,omitempty"`
 		Title string `json:"title,omitempty"`
 	}
-	Fridge2716213877Views []*Fridge2716213877View
+	FridgeViews []*FridgeView
 )
 
-func NewFridge2716213877View(e *ent.Fridge) *Fridge2716213877View {
+func NewFridgeView(e *ent.Fridge) *FridgeView {
 	if e == nil {
 		return nil
 	}
-	return &Fridge2716213877View{
+	return &FridgeView{
 		ID:    e.ID,
 		Title: e.Title,
 	}
 }
 
-func NewFridge2716213877Views(es []*ent.Fridge) Fridge2716213877Views {
+func NewFridgeViews(es []*ent.Fridge) FridgeViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Fridge2716213877Views, len(es))
+	r := make(FridgeViews, len(es))
 	for i, e := range es {
-		r[i] = NewFridge2716213877View(e)
+		r[i] = NewFridgeView(e)
 	}
 	return r
 }
 
 type (
-	// Item1509516544View represents the data serialized for the following serialization group combinations:
+	// ItemView represents the data serialized for the following serialization group combinations:
 	// []
-	Item1509516544View struct {
+	ItemView struct {
 		ID   int    `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
 	}
-	Item1509516544Views []*Item1509516544View
+	ItemViews []*ItemView
 )
 
-func NewItem1509516544View(e *ent.Item) *Item1509516544View {
+func NewItemView(e *ent.Item) *ItemView {
 	if e == nil {
 		return nil
 	}
-	return &Item1509516544View{
+	return &ItemView{
 		ID:   e.ID,
 		Name: e.Name,
 	}
 }
 
-func NewItem1509516544Views(es []*ent.Item) Item1509516544Views {
+func NewItemViews(es []*ent.Item) ItemViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Item1509516544Views, len(es))
+	r := make(ItemViews, len(es))
 	for i, e := range es {
-		r[i] = NewItem1509516544View(e)
+		r[i] = NewItemView(e)
 	}
 	return r
 }

--- a/internal/fridge/ent/http/update.go
+++ b/internal/fridge/ent/http/update.go
@@ -82,7 +82,7 @@ func (h CompartmentHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("compartment rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCompartment1151786357View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCompartmentView(e), w)
 }
 
 // Update updates a given ent.Fridge and saves the changes to the database.
@@ -148,7 +148,7 @@ func (h FridgeHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("fridge rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewFridge2716213877View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewFridgeView(e), w)
 }
 
 // Update updates a given ent.Item and saves the changes to the database.
@@ -215,5 +215,5 @@ func (h ItemHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("item rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewItem1509516544View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewItemView(e), w)
 }

--- a/internal/fridge/ent/openapi.json
+++ b/internal/fridge/ent/openapi.json
@@ -46,7 +46,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Compartment1151786357View"
+                    "$ref": "#/components/schemas/CompartmentView"
                   }
                 }
               }
@@ -105,7 +105,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Compartment1151786357View"
+                  "$ref": "#/components/schemas/CompartmentView"
                 }
               }
             }
@@ -145,7 +145,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Compartment1151786357View"
+                  "$ref": "#/components/schemas/CompartmentView"
                 }
               }
             }
@@ -249,7 +249,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Compartment1151786357View"
+                  "$ref": "#/components/schemas/CompartmentView"
                 }
               }
             }
@@ -312,7 +312,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Item1509516544View"
+                    "$ref": "#/components/schemas/ItemView"
                   }
                 }
               }
@@ -356,7 +356,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Fridge2716213877View"
+                  "$ref": "#/components/schemas/FridgeView"
                 }
               }
             }
@@ -409,7 +409,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Fridge2716213877View"
+                    "$ref": "#/components/schemas/FridgeView"
                   }
                 }
               }
@@ -464,7 +464,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Fridge2716213877View"
+                  "$ref": "#/components/schemas/FridgeView"
                 }
               }
             }
@@ -504,7 +504,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Fridge2716213877View"
+                  "$ref": "#/components/schemas/FridgeView"
                 }
               }
             }
@@ -570,7 +570,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Fridge2716213877View"
+                  "$ref": "#/components/schemas/FridgeView"
                 }
               }
             }
@@ -633,7 +633,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Compartment1151786357View"
+                    "$ref": "#/components/schemas/CompartmentView"
                   }
                 }
               }
@@ -735,7 +735,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Item1509516544View"
+                    "$ref": "#/components/schemas/ItemView"
                   }
                 }
               }
@@ -787,7 +787,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Item1509516544View"
+                  "$ref": "#/components/schemas/ItemView"
                 }
               }
             }
@@ -827,7 +827,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Item1509516544View"
+                  "$ref": "#/components/schemas/ItemView"
                 }
               }
             }
@@ -924,7 +924,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Item1509516544View"
+                  "$ref": "#/components/schemas/ItemView"
                 }
               }
             }
@@ -967,7 +967,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Compartment1151786357View"
+                  "$ref": "#/components/schemas/CompartmentView"
                 }
               }
             }
@@ -987,7 +987,7 @@
   },
   "components": {
     "schemas": {
-      "Compartment1151786357View": {
+      "CompartmentView": {
         "type": "object",
         "required": [
           "id",
@@ -1003,7 +1003,7 @@
           }
         }
       },
-      "Fridge2716213877View": {
+      "FridgeView": {
         "type": "object",
         "required": [
           "id",
@@ -1019,7 +1019,7 @@
           }
         }
       },
-      "Item1509516544View": {
+      "ItemView": {
         "type": "object",
         "required": [
           "id",

--- a/internal/openapi/ent/openapi.json
+++ b/internal/openapi/ent/openapi.json
@@ -304,7 +304,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PetWithPetListView"
+                    "$ref": "#/components/schemas/PetListView"
                   }
                 }
               }
@@ -626,7 +626,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PetWithPetListView"
+                    "$ref": "#/components/schemas/PetListView"
                   }
                 }
               }
@@ -680,7 +680,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PetWithPetListView"
+                    "$ref": "#/components/schemas/PetListView"
                   }
                 }
               }
@@ -741,6 +741,12 @@
                   "name": {
                     "type": "string",
                     "example": "Kuro"
+                  },
+                  "nicknames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   "owner": {
                     "type": "integer",
@@ -914,6 +920,12 @@
                     "type": "string",
                     "example": "Kuro"
                   },
+                  "nicknames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "owner": {
                     "type": "integer",
                     "format": "int32"
@@ -1061,7 +1073,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PetWithPetListView"
+                    "$ref": "#/components/schemas/PetListView"
                   }
                 }
               }
@@ -1141,6 +1153,54 @@
           }
         }
       },
+      "CategoryWithFriendAndOwnerView": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "CategoryWithFriendView": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "CategoryWithPetListView": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "OwnerView": {
         "type": "object",
         "required": [
@@ -1159,6 +1219,71 @@
           },
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "OwnerWithFriendView": {
+        "type": "object",
+        "required": [
+          "age",
+          "id",
+          "name"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "OwnerWithPetListView": {
+        "type": "object",
+        "required": [
+          "age",
+          "id",
+          "name"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "PetListView": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "example": 1
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CategoryWithPetListView"
+            }
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
@@ -1181,6 +1306,12 @@
           "name": {
             "type": "string",
             "example": "Kuro"
+          },
+          "nicknames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -1206,7 +1337,7 @@
             "format": "int32"
           },
           "owner": {
-            "$ref": "#/components/schemas/OwnerView"
+            "$ref": "#/components/schemas/OwnerWithFriendView"
           }
         }
       },
@@ -1225,29 +1356,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PetWithFriendView"
-            }
-          },
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "PetWithPetListView": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "age": {
-            "type": "integer",
-            "format": "int32",
-            "example": 1
-          },
-          "categories": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CategoryView"
             }
           },
           "id": {

--- a/internal/openapi/ent/openapi.json
+++ b/internal/openapi/ent/openapi.json
@@ -46,7 +46,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category4094953247View"
+                    "$ref": "#/components/schemas/CategoryView"
                   }
                 }
               }
@@ -101,7 +101,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -141,7 +141,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -241,7 +241,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -304,7 +304,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet2903321980View"
+                    "$ref": "#/components/schemas/PetWithPetListView"
                   }
                 }
               }
@@ -358,7 +358,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Owner139708381View"
+                    "$ref": "#/components/schemas/OwnerView"
                   }
                 }
               }
@@ -418,7 +418,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -458,7 +458,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -563,7 +563,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -626,7 +626,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet2903321980View"
+                    "$ref": "#/components/schemas/PetWithPetListView"
                   }
                 }
               }
@@ -680,7 +680,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet2903321980View"
+                    "$ref": "#/components/schemas/PetWithPetListView"
                   }
                 }
               }
@@ -742,12 +742,6 @@
                     "type": "string",
                     "example": "Kuro"
                   },
-                  "nicknames": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "owner": {
                     "type": "integer",
                     "format": "int32"
@@ -763,7 +757,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet2903321980View"
+                  "$ref": "#/components/schemas/PetWithFriendView"
                 }
               }
             }
@@ -808,7 +802,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet1876743790View"
+                  "$ref": "#/components/schemas/PetWithFriendAndOwnerView"
                 }
               }
             }
@@ -920,12 +914,6 @@
                     "type": "string",
                     "example": "Kuro"
                   },
-                  "nicknames": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "owner": {
                     "type": "integer",
                     "format": "int32"
@@ -941,7 +929,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet2903321980View"
+                  "$ref": "#/components/schemas/PetView"
                 }
               }
             }
@@ -1009,7 +997,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category4094953247View"
+                    "$ref": "#/components/schemas/CategoryView"
                   }
                 }
               }
@@ -1073,7 +1061,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet2903321980View"
+                    "$ref": "#/components/schemas/PetWithPetListView"
                   }
                 }
               }
@@ -1117,7 +1105,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -1137,7 +1125,7 @@
   },
   "components": {
     "schemas": {
-      "Category4094953247View": {
+      "CategoryView": {
         "type": "object",
         "required": [
           "id",
@@ -1153,7 +1141,7 @@
           }
         }
       },
-      "Owner139708381View": {
+      "OwnerView": {
         "type": "object",
         "required": [
           "age",
@@ -1174,11 +1162,32 @@
           }
         }
       },
-      "Pet1876743790View": {
+      "PetView": {
         "type": "object",
         "required": [
           "id",
           "name"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "example": 1
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "example": "Kuro"
+          }
+        }
+      },
+      "PetWithFriendAndOwnerView": {
+        "type": "object",
+        "required": [
+          "id"
         ],
         "properties": {
           "age": {
@@ -1187,27 +1196,24 @@
             "example": 1
           },
           "friends": {
-            "type": "object",
-            "properties": {}
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PetWithFriendAndOwnerView"
+            }
           },
           "id": {
             "type": "integer",
             "format": "int32"
           },
-          "name": {
-            "type": "string",
-            "example": "Kuro"
-          },
           "owner": {
-            "$ref": "#/components/schemas/Owner139708381View"
+            "$ref": "#/components/schemas/OwnerView"
           }
         }
       },
-      "Pet2903321980View": {
+      "PetWithFriendView": {
         "type": "object",
         "required": [
-          "id",
-          "name"
+          "id"
         ],
         "properties": {
           "age": {
@@ -1215,19 +1221,38 @@
             "format": "int32",
             "example": 1
           },
+          "friends": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PetWithFriendView"
+            }
+          },
           "id": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "PetWithPetListView": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "example": 1
           },
-          "name": {
-            "type": "string",
-            "example": "Kuro"
-          },
-          "nicknames": {
+          "categories": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/CategoryView"
             }
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       }

--- a/internal/openapi/ent/schema/pet.go
+++ b/internal/openapi/ent/schema/pet.go
@@ -37,14 +37,16 @@ func (Pet) Fields() []ent.Field {
 func (Pet) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("categories", Category.Type).
+			Annotations(elk.Groups("pet:list")).
 			Ref("pets"),
+
 		edge.From("owner", Owner.Type).
 			Ref("pets").
 			Unique().
-			Annotations(elk.Groups("pet:owner")),
+			Annotations(elk.Groups("owner")),
 		edge.To("friends", Pet.Type).
 			Annotations(
-				elk.Groups("pet"),
+				elk.Groups("friend"),
 				elk.MaxDepth(3),
 			),
 	}
@@ -53,7 +55,9 @@ func (Pet) Edges() []ent.Edge {
 // Annotations of the Pet.
 func (Pet) Annotations() []schema.Annotation {
 	return []schema.Annotation{
-		elk.ReadGroups("pet", "pet:owner", "owner"),
+		elk.ReadGroups("friend", "owner"),
+		elk.ListGroups("pet:list"),
+		elk.CreateGroups("friend"),
 		elk.SchemaSecurity(spec.Security{{"apiKeySample": {}}}),
 	}
 }

--- a/internal/pets/ent/http/create.go
+++ b/internal/pets/ent/http/create.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	"github.com/masseelch/elk/internal/pets/ent/badge"
-	"github.com/masseelch/elk/internal/pets/ent/pet"
-	"github.com/masseelch/elk/internal/pets/ent/playgroup"
-	"github.com/masseelch/elk/internal/pets/ent/toy"
+	badge "github.com/masseelch/elk/internal/pets/ent/badge"
+	pet "github.com/masseelch/elk/internal/pets/ent/pet"
+	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
+	toy "github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 

--- a/internal/pets/ent/http/create.go
+++ b/internal/pets/ent/http/create.go
@@ -45,29 +45,27 @@ func (h BadgeHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Badge.Query().Where(badge.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Uint32("id", id))
+			l.Info(msg, zap.Error(err), zap.Uint32("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Uint32("id", id))
+			l.Error(msg, zap.Error(err), zap.Uint32("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read badge", zap.Error(err), zap.Uint32("id", id))
+			l.Error("could not read badge", zap.Error(err), zap.Uint32("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("badge rendered", zap.Uint32("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewBadge2492344257View(ret), w)
+	l.Info("badge rendered", zap.Uint32("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewBadgeView(e), w)
 }
 
 // Create creates a new ent.Pet and stores it in the database.
@@ -175,8 +173,6 @@ func (h PetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Pet.Query().Where(pet.ID(e.ID))
 	// Eager load edges that are required on create operation.
@@ -1225,25 +1221,25 @@ func (h PetHandler) Create(w http.ResponseWriter, r *http.Request) {
 			}).WithPlayGroups()
 		})
 	})
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", id))
+			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", id))
+			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read pet", zap.Error(err), zap.Int("id", id))
+			l.Error("could not read pet", zap.Error(err), zap.Int("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("pet rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(ret), w)
+	l.Info("pet rendered", zap.Int("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Create creates a new ent.PlayGroup and stores it in the database.
@@ -1279,29 +1275,27 @@ func (h PlayGroupHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.PlayGroup.Query().Where(playgroup.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", id))
+			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", id))
+			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read play-group", zap.Error(err), zap.Int("id", id))
+			l.Error("could not read play-group", zap.Error(err), zap.Int("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("play-group rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPlayGroup3432834655View(ret), w)
+	l.Info("play-group rendered", zap.Int("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewPlayGroupView(e), w)
 }
 
 // Create creates a new ent.Toy and stores it in the database.
@@ -1337,27 +1331,25 @@ func (h ToyHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Toy.Query().Where(toy.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.String("id", id.String()))
+			l.Info(msg, zap.Error(err), zap.String("id", e.ID.String()))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.String("id", id.String()))
+			l.Error(msg, zap.Error(err), zap.String("id", e.ID.String()))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read toy", zap.Error(err), zap.String("id", id.String()))
+			l.Error("could not read toy", zap.Error(err), zap.String("id", e.ID.String()))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("toy rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewToy36157710View(ret), w)
+	l.Info("toy rendered", zap.String("id", e.ID.String()))
+	easyjson.MarshalToHTTPResponseWriter(NewToyView(e), w)
 }

--- a/internal/pets/ent/http/create.go
+++ b/internal/pets/ent/http/create.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	badge "github.com/masseelch/elk/internal/pets/ent/badge"
-	pet "github.com/masseelch/elk/internal/pets/ent/pet"
-	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
-	toy "github.com/masseelch/elk/internal/pets/ent/toy"
+	"github.com/masseelch/elk/internal/pets/ent/badge"
+	"github.com/masseelch/elk/internal/pets/ent/pet"
+	"github.com/masseelch/elk/internal/pets/ent/playgroup"
+	"github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 
@@ -45,27 +45,29 @@ func (h BadgeHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Badge.Query().Where(badge.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Uint32("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Uint32("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Uint32("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Uint32("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read badge", zap.Error(err), zap.Uint32("id", e.ID))
+			l.Error("could not read badge", zap.Error(err), zap.Uint32("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("badge rendered", zap.Uint32("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewBadgeView(e), w)
+	l.Info("badge rendered", zap.Uint32("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewBadgeView(ret), w)
 }
 
 // Create creates a new ent.Pet and stores it in the database.
@@ -173,6 +175,8 @@ func (h PetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Pet.Query().Where(pet.ID(e.ID))
 	// Eager load edges that are required on create operation.
@@ -1221,25 +1225,25 @@ func (h PetHandler) Create(w http.ResponseWriter, r *http.Request) {
 			}).WithPlayGroups()
 		})
 	})
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Int("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Int("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read pet", zap.Error(err), zap.Int("id", e.ID))
+			l.Error("could not read pet", zap.Error(err), zap.Int("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	l.Info("pet rendered", zap.Int("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewPetListAndPetReadView(ret), w)
 }
 
 // Create creates a new ent.PlayGroup and stores it in the database.
@@ -1275,27 +1279,29 @@ func (h PlayGroupHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.PlayGroup.Query().Where(playgroup.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Int("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Int("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read play-group", zap.Error(err), zap.Int("id", e.ID))
+			l.Error("could not read play-group", zap.Error(err), zap.Int("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("play-group rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPlayGroupView(e), w)
+	l.Info("play-group rendered", zap.Int("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewPlayGroupView(ret), w)
 }
 
 // Create creates a new ent.Toy and stores it in the database.
@@ -1331,25 +1337,27 @@ func (h ToyHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Toy.Query().Where(toy.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.String("id", e.ID.String()))
+			l.Info(msg, zap.Error(err), zap.String("id", id.String()))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.String("id", e.ID.String()))
+			l.Error(msg, zap.Error(err), zap.String("id", id.String()))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read toy", zap.Error(err), zap.String("id", e.ID.String()))
+			l.Error("could not read toy", zap.Error(err), zap.String("id", id.String()))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("toy rendered", zap.String("id", e.ID.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewToyView(e), w)
+	l.Info("toy rendered", zap.String("id", id.String()))
+	easyjson.MarshalToHTTPResponseWriter(NewToyView(ret), w)
 }

--- a/internal/pets/ent/http/easyjson.go
+++ b/internal/pets/ent/http/easyjson.go
@@ -23,7 +23,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(in *jlexer.Lexer, out *ToyViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(in *jlexer.Lexer, out *ToyWithPetReadViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -32,21 +32,21 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(in *jlexer.L
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(ToyViews, 0, 8)
+				*out = make(ToyWithPetReadViews, 0, 8)
 			} else {
-				*out = ToyViews{}
+				*out = ToyWithPetReadViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v1 *ToyView
+			var v1 *ToyWithPetReadView
 			if in.IsNull() {
 				in.Skip()
 				v1 = nil
 			} else {
 				if v1 == nil {
-					v1 = new(ToyView)
+					v1 = new(ToyWithPetReadView)
 				}
 				(*v1).UnmarshalEasyJSON(in)
 			}
@@ -59,7 +59,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(in *jlexer.L
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(out *jwriter.Writer, in ToyViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(out *jwriter.Writer, in ToyWithPetReadViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
@@ -79,15 +79,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(out *jwriter
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ToyViews) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ToyWithPetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *ToyViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *ToyWithPetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(in *jlexer.Lexer, out *ToyView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(in *jlexer.Lexer, out *ToyWithPetReadView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -130,7 +130,484 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(out *jwriter.Writer, in ToyView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(out *jwriter.Writer, in ToyWithPetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if true {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.RawText((in.ID).MarshalText())
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	if in.Material != "" {
+		const prefix string = ",\"material\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Material))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyWithPetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyWithPetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(in *jlexer.Lexer, out *ToyWithPetListViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(ToyWithPetListViews, 0, 8)
+			} else {
+				*out = ToyWithPetListViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v4 *ToyWithPetListView
+			if in.IsNull() {
+				in.Skip()
+				v4 = nil
+			} else {
+				if v4 == nil {
+					v4 = new(ToyWithPetListView)
+				}
+				(*v4).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v4)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(out *jwriter.Writer, in ToyWithPetListViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v5, v6 := range in {
+			if v5 > 0 {
+				out.RawByte(',')
+			}
+			if v6 == nil {
+				out.RawString("null")
+			} else {
+				(*v6).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyWithPetListViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyWithPetListViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(in *jlexer.Lexer, out *ToyWithPetListView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.ID).UnmarshalText(data))
+			}
+		case "color":
+			out.Color = toy.Color(in.String())
+		case "material":
+			out.Material = toy.Material(in.String())
+		case "title":
+			out.Title = string(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(out *jwriter.Writer, in ToyWithPetListView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if true {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.RawText((in.ID).MarshalText())
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	if in.Material != "" {
+		const prefix string = ",\"material\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Material))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyWithPetListView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyWithPetListView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(in *jlexer.Lexer, out *ToyWithPetListAndPetReadViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(ToyWithPetListAndPetReadViews, 0, 8)
+			} else {
+				*out = ToyWithPetListAndPetReadViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v7 *ToyWithPetListAndPetReadView
+			if in.IsNull() {
+				in.Skip()
+				v7 = nil
+			} else {
+				if v7 == nil {
+					v7 = new(ToyWithPetListAndPetReadView)
+				}
+				(*v7).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v7)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(out *jwriter.Writer, in ToyWithPetListAndPetReadViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v8, v9 := range in {
+			if v8 > 0 {
+				out.RawByte(',')
+			}
+			if v9 == nil {
+				out.RawString("null")
+			} else {
+				(*v9).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyWithPetListAndPetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyWithPetListAndPetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(in *jlexer.Lexer, out *ToyWithPetListAndPetReadView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.ID).UnmarshalText(data))
+			}
+		case "color":
+			out.Color = toy.Color(in.String())
+		case "material":
+			out.Material = toy.Material(in.String())
+		case "title":
+			out.Title = string(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(out *jwriter.Writer, in ToyWithPetListAndPetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if true {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.RawText((in.ID).MarshalText())
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	if in.Material != "" {
+		const prefix string = ",\"material\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Material))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyWithPetListAndPetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyWithPetListAndPetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.Lexer, out *ToyViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(ToyViews, 0, 8)
+			} else {
+				*out = ToyViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v10 *ToyView
+			if in.IsNull() {
+				in.Skip()
+				v10 = nil
+			} else {
+				if v10 == nil {
+					v10 = new(ToyView)
+				}
+				(*v10).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v10)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(out *jwriter.Writer, in ToyViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v11, v12 := range in {
+			if v11 > 0 {
+				out.RawByte(',')
+			}
+			if v12 == nil {
+				out.RawString("null")
+			} else {
+				(*v12).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.Lexer, out *ToyView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.ID).UnmarshalText(data))
+			}
+		case "color":
+			out.Color = toy.Color(in.String())
+		case "material":
+			out.Material = toy.Material(in.String())
+		case "title":
+			out.Title = string(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(out *jwriter.Writer, in ToyView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -175,14 +652,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ToyView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ToyView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(in *jlexer.Lexer, out *ToyUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.Lexer, out *ToyUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -255,7 +732,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(out *jwriter.Writer, in ToyUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwriter.Writer, in ToyUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -300,14 +777,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ToyUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ToyUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(in *jlexer.Lexer, out *ToyCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.Lexer, out *ToyCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -380,7 +857,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(out *jwriter.Writer, in ToyCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwriter.Writer, in ToyCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -425,14 +902,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ToyCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ToyCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(in *jlexer.Lexer, out *PlayGroupViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer.Lexer, out *PlayGroupWithPetReadViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -441,25 +918,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(in *jlexer.
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(PlayGroupViews, 0, 8)
+				*out = make(PlayGroupWithPetReadViews, 0, 8)
 			} else {
-				*out = PlayGroupViews{}
+				*out = PlayGroupWithPetReadViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v4 *PlayGroupView
+			var v13 *PlayGroupWithPetReadView
 			if in.IsNull() {
 				in.Skip()
-				v4 = nil
+				v13 = nil
 			} else {
-				if v4 == nil {
-					v4 = new(PlayGroupView)
+				if v13 == nil {
+					v13 = new(PlayGroupWithPetReadView)
 				}
-				(*v4).UnmarshalEasyJSON(in)
+				(*v13).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v4)
+			*out = append(*out, v13)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -468,19 +945,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(out *jwriter.Writer, in PlayGroupViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwriter.Writer, in PlayGroupWithPetReadViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v5, v6 := range in {
-			if v5 > 0 {
+		for v14, v15 := range in {
+			if v14 > 0 {
 				out.RawByte(',')
 			}
-			if v6 == nil {
+			if v15 == nil {
 				out.RawString("null")
 			} else {
-				(*v6).MarshalEasyJSON(out)
+				(*v15).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -488,15 +965,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(out *jwrite
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PlayGroupViews) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(w, v)
+func (v PlayGroupWithPetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PlayGroupViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(l, v)
+func (v *PlayGroupWithPetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(in *jlexer.Lexer, out *PlayGroupView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer.Lexer, out *PlayGroupWithPetReadView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -537,7 +1014,478 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(out *jwriter.Writer, in PlayGroupView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwriter.Writer, in PlayGroupWithPetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	if in.Description != "" {
+		const prefix string = ",\"description\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Description))
+	}
+	if in.Weekday != "" {
+		const prefix string = ",\"weekday\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Weekday))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PlayGroupWithPetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PlayGroupWithPetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(in *jlexer.Lexer, out *PlayGroupWithPetListViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PlayGroupWithPetListViews, 0, 8)
+			} else {
+				*out = PlayGroupWithPetListViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v16 *PlayGroupWithPetListView
+			if in.IsNull() {
+				in.Skip()
+				v16 = nil
+			} else {
+				if v16 == nil {
+					v16 = new(PlayGroupWithPetListView)
+				}
+				(*v16).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v16)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(out *jwriter.Writer, in PlayGroupWithPetListViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v17, v18 := range in {
+			if v17 > 0 {
+				out.RawByte(',')
+			}
+			if v18 == nil {
+				out.RawString("null")
+			} else {
+				(*v18).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PlayGroupWithPetListViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PlayGroupWithPetListViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(in *jlexer.Lexer, out *PlayGroupWithPetListView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "title":
+			out.Title = string(in.String())
+		case "description":
+			out.Description = string(in.String())
+		case "weekday":
+			out.Weekday = playgroup.Weekday(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(out *jwriter.Writer, in PlayGroupWithPetListView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	if in.Description != "" {
+		const prefix string = ",\"description\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Description))
+	}
+	if in.Weekday != "" {
+		const prefix string = ",\"weekday\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Weekday))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PlayGroupWithPetListView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PlayGroupWithPetListView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(in *jlexer.Lexer, out *PlayGroupWithPetListAndPetReadViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PlayGroupWithPetListAndPetReadViews, 0, 8)
+			} else {
+				*out = PlayGroupWithPetListAndPetReadViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v19 *PlayGroupWithPetListAndPetReadView
+			if in.IsNull() {
+				in.Skip()
+				v19 = nil
+			} else {
+				if v19 == nil {
+					v19 = new(PlayGroupWithPetListAndPetReadView)
+				}
+				(*v19).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v19)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(out *jwriter.Writer, in PlayGroupWithPetListAndPetReadViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v20, v21 := range in {
+			if v20 > 0 {
+				out.RawByte(',')
+			}
+			if v21 == nil {
+				out.RawString("null")
+			} else {
+				(*v21).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PlayGroupWithPetListAndPetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PlayGroupWithPetListAndPetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(in *jlexer.Lexer, out *PlayGroupWithPetListAndPetReadView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "title":
+			out.Title = string(in.String())
+		case "description":
+			out.Description = string(in.String())
+		case "weekday":
+			out.Weekday = playgroup.Weekday(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(out *jwriter.Writer, in PlayGroupWithPetListAndPetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	if in.Description != "" {
+		const prefix string = ",\"description\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Description))
+	}
+	if in.Weekday != "" {
+		const prefix string = ",\"weekday\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Weekday))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PlayGroupWithPetListAndPetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PlayGroupWithPetListAndPetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(in *jlexer.Lexer, out *PlayGroupViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PlayGroupViews, 0, 8)
+			} else {
+				*out = PlayGroupViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v22 *PlayGroupView
+			if in.IsNull() {
+				in.Skip()
+				v22 = nil
+			} else {
+				if v22 == nil {
+					v22 = new(PlayGroupView)
+				}
+				(*v22).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v22)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(out *jwriter.Writer, in PlayGroupViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v23, v24 := range in {
+			if v23 > 0 {
+				out.RawByte(',')
+			}
+			if v24 == nil {
+				out.RawString("null")
+			} else {
+				(*v24).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PlayGroupViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PlayGroupViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp17(in *jlexer.Lexer, out *PlayGroupView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "title":
+			out.Title = string(in.String())
+		case "description":
+			out.Description = string(in.String())
+		case "weekday":
+			out.Weekday = playgroup.Weekday(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp17(out *jwriter.Writer, in PlayGroupView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -582,14 +1530,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PlayGroupView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp17(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PlayGroupView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp17(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.Lexer, out *PlayGroupUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp18(in *jlexer.Lexer, out *PlayGroupUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -654,9 +1602,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.
 					out.Participants = (out.Participants)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v7 int
-					v7 = int(in.Int())
-					out.Participants = append(out.Participants, v7)
+					var v25 int
+					v25 = int(in.Int())
+					out.Participants = append(out.Participants, v25)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -675,7 +1623,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(out *jwriter.Writer, in PlayGroupUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp18(out *jwriter.Writer, in PlayGroupUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -713,11 +1661,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v8, v9 := range in.Participants {
-				if v8 > 0 {
+			for v26, v27 := range in.Participants {
+				if v26 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v9))
+				out.Int(int(v27))
 			}
 			out.RawByte(']')
 		}
@@ -727,14 +1675,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PlayGroupUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp18(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PlayGroupUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp18(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.Lexer, out *PlayGroupCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp19(in *jlexer.Lexer, out *PlayGroupCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -799,9 +1747,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.
 					out.Participants = (out.Participants)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v10 int
-					v10 = int(in.Int())
-					out.Participants = append(out.Participants, v10)
+					var v28 int
+					v28 = int(in.Int())
+					out.Participants = append(out.Participants, v28)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -820,7 +1768,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(out *jwriter.Writer, in PlayGroupCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp19(out *jwriter.Writer, in PlayGroupCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -858,11 +1806,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v11, v12 := range in.Participants {
-				if v11 > 0 {
+			for v29, v30 := range in.Participants {
+				if v29 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v12))
+				out.Int(int(v30))
 			}
 			out.RawByte(']')
 		}
@@ -872,14 +1820,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PlayGroupCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp19(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PlayGroupCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp19(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.Lexer, out *PetViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp20(in *jlexer.Lexer, out *PetViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -896,17 +1844,17 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v13 *PetView
+			var v31 *PetView
 			if in.IsNull() {
 				in.Skip()
-				v13 = nil
+				v31 = nil
 			} else {
-				if v13 == nil {
-					v13 = new(PetView)
+				if v31 == nil {
+					v31 = new(PetView)
 				}
-				(*v13).UnmarshalEasyJSON(in)
+				(*v31).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v13)
+			*out = append(*out, v31)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -915,19 +1863,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwriter.Writer, in PetViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp20(out *jwriter.Writer, in PetViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v14, v15 := range in {
-			if v14 > 0 {
+		for v32, v33 := range in {
+			if v32 > 0 {
 				out.RawByte(',')
 			}
-			if v15 == nil {
+			if v33 == nil {
 				out.RawString("null")
 			} else {
-				(*v15).MarshalEasyJSON(out)
+				(*v33).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -936,14 +1884,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetViews) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp20(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp20(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.Lexer, out *PetView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp21(in *jlexer.Lexer, out *PetView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -992,9 +1940,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 					out.Nicknames = (out.Nicknames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v16 string
-					v16 = string(in.String())
-					out.Nicknames = append(out.Nicknames, v16)
+					var v34 string
+					v34 = string(in.String())
+					out.Nicknames = append(out.Nicknames, v34)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1019,7 +1967,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwriter.Writer, in PetView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp21(out *jwriter.Writer, in PetView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1089,11 +2037,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 		}
 		{
 			out.RawByte('[')
-			for v17, v18 := range in.Nicknames {
-				if v17 > 0 {
+			for v35, v36 := range in.Nicknames {
+				if v35 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v18))
+				out.String(string(v36))
 			}
 			out.RawByte(']')
 		}
@@ -1123,14 +2071,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp21(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp21(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer.Lexer, out *PetUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp22(in *jlexer.Lexer, out *PetUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1224,9 +2172,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer
 						*out.Nicknames = (*out.Nicknames)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v19 string
-						v19 = string(in.String())
-						*out.Nicknames = append(*out.Nicknames, v19)
+						var v37 string
+						v37 = string(in.String())
+						*out.Nicknames = append(*out.Nicknames, v37)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -1300,11 +2248,11 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer
 					out.Toys = (out.Toys)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v20 uuid.UUID
+					var v38 uuid.UUID
 					if data := in.UnsafeBytes(); in.Ok() {
-						in.AddError((v20).UnmarshalText(data))
+						in.AddError((v38).UnmarshalText(data))
 					}
-					out.Toys = append(out.Toys, v20)
+					out.Toys = append(out.Toys, v38)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1335,9 +2283,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer
 					out.Children = (out.Children)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v21 int
-					v21 = int(in.Int())
-					out.Children = append(out.Children, v21)
+					var v39 int
+					v39 = int(in.Int())
+					out.Children = append(out.Children, v39)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1358,9 +2306,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer
 					out.PlayGroups = (out.PlayGroups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v22 int
-					v22 = int(in.Int())
-					out.PlayGroups = append(out.PlayGroups, v22)
+					var v40 int
+					v40 = int(in.Int())
+					out.PlayGroups = append(out.PlayGroups, v40)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1381,9 +2329,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer
 					out.Friends = (out.Friends)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v23 int
-					v23 = int(in.Int())
-					out.Friends = append(out.Friends, v23)
+					var v41 int
+					v41 = int(in.Int())
+					out.Friends = append(out.Friends, v41)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1402,7 +2350,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwriter.Writer, in PetUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp22(out *jwriter.Writer, in PetUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1461,11 +2409,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwrit
 				out.RawString("null")
 			} else {
 				out.RawByte('[')
-				for v24, v25 := range *in.Nicknames {
-					if v24 > 0 {
+				for v42, v43 := range *in.Nicknames {
+					if v42 > 0 {
 						out.RawByte(',')
 					}
-					out.String(string(v25))
+					out.String(string(v43))
 				}
 				out.RawByte(']')
 			}
@@ -1523,11 +2471,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v26, v27 := range in.Toys {
-				if v26 > 0 {
+			for v44, v45 := range in.Toys {
+				if v44 > 0 {
 					out.RawByte(',')
 				}
-				out.RawText((v27).MarshalText())
+				out.RawText((v45).MarshalText())
 			}
 			out.RawByte(']')
 		}
@@ -1548,11 +2496,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v28, v29 := range in.Children {
-				if v28 > 0 {
+			for v46, v47 := range in.Children {
+				if v46 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v29))
+				out.Int(int(v47))
 			}
 			out.RawByte(']')
 		}
@@ -1564,11 +2512,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v30, v31 := range in.PlayGroups {
-				if v30 > 0 {
+			for v48, v49 := range in.PlayGroups {
+				if v48 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v31))
+				out.Int(int(v49))
 			}
 			out.RawByte(']')
 		}
@@ -1580,11 +2528,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v32, v33 := range in.Friends {
-				if v32 > 0 {
+			for v50, v51 := range in.Friends {
+				if v50 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v33))
+				out.Int(int(v51))
 			}
 			out.RawByte(']')
 		}
@@ -1594,14 +2542,927 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwrit
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp22(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp22(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer.Lexer, out *PetCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp23(in *jlexer.Lexer, out *PetReadViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PetReadViews, 0, 8)
+			} else {
+				*out = PetReadViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v52 *PetReadView
+			if in.IsNull() {
+				in.Skip()
+				v52 = nil
+			} else {
+				if v52 == nil {
+					v52 = new(PetReadView)
+				}
+				(*v52).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v52)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp23(out *jwriter.Writer, in PetReadViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v53, v54 := range in {
+			if v53 > 0 {
+				out.RawByte(',')
+			}
+			if v54 == nil {
+				out.RawString("null")
+			} else {
+				(*v54).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp23(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp23(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp24(in *jlexer.Lexer, out *PetReadView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "height":
+			out.Height = int(in.Int())
+		case "weight":
+			out.Weight = float64(in.Float64())
+		case "castrated":
+			out.Castrated = bool(in.Bool())
+		case "name":
+			out.Name = string(in.String())
+		case "birthday":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Birthday).UnmarshalJSON(data))
+			}
+		case "nicknames":
+			if in.IsNull() {
+				in.Skip()
+				out.Nicknames = nil
+			} else {
+				in.Delim('[')
+				if out.Nicknames == nil {
+					if !in.IsDelim(']') {
+						out.Nicknames = make([]string, 0, 4)
+					} else {
+						out.Nicknames = []string{}
+					}
+				} else {
+					out.Nicknames = (out.Nicknames)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v55 string
+					v55 = string(in.String())
+					out.Nicknames = append(out.Nicknames, v55)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "sex":
+			out.Sex = pet.Sex(in.String())
+		case "chip":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.Chip).UnmarshalText(data))
+			}
+		case "badge":
+			if in.IsNull() {
+				in.Skip()
+				out.Badge = nil
+			} else {
+				if out.Badge == nil {
+					out.Badge = new(BadgeWithPetReadView)
+				}
+				(*out.Badge).UnmarshalEasyJSON(in)
+			}
+		case "protege":
+			if in.IsNull() {
+				in.Skip()
+				out.Protege = nil
+			} else {
+				if out.Protege == nil {
+					out.Protege = new(PetReadView)
+				}
+				(*out.Protege).UnmarshalEasyJSON(in)
+			}
+		case "spouse":
+			if in.IsNull() {
+				in.Skip()
+				out.Spouse = nil
+			} else {
+				if out.Spouse == nil {
+					out.Spouse = new(PetReadView)
+				}
+				(*out.Spouse).UnmarshalEasyJSON(in)
+			}
+		case "toys":
+			(out.Toys).UnmarshalEasyJSON(in)
+		case "parent":
+			if in.IsNull() {
+				in.Skip()
+				out.Parent = nil
+			} else {
+				if out.Parent == nil {
+					out.Parent = new(PetReadView)
+				}
+				(*out.Parent).UnmarshalEasyJSON(in)
+			}
+		case "play_groups":
+			(out.PlayGroups).UnmarshalEasyJSON(in)
+		case "friends":
+			(out.Friends).UnmarshalEasyJSON(in)
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp24(out *jwriter.Writer, in PetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Height != 0 {
+		const prefix string = ",\"height\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.Height))
+	}
+	if in.Weight != 0 {
+		const prefix string = ",\"weight\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Float64(float64(in.Weight))
+	}
+	if in.Castrated {
+		const prefix string = ",\"castrated\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.Castrated))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if true {
+		const prefix string = ",\"birthday\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.Birthday).MarshalJSON())
+	}
+	if len(in.Nicknames) != 0 {
+		const prefix string = ",\"nicknames\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v56, v57 := range in.Nicknames {
+				if v56 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v57))
+			}
+			out.RawByte(']')
+		}
+	}
+	if in.Sex != "" {
+		const prefix string = ",\"sex\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Sex))
+	}
+	if true {
+		const prefix string = ",\"chip\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.RawText((in.Chip).MarshalText())
+	}
+	if in.Badge != nil {
+		const prefix string = ",\"badge\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Badge).MarshalEasyJSON(out)
+	}
+	if in.Protege != nil {
+		const prefix string = ",\"protege\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Protege).MarshalEasyJSON(out)
+	}
+	if in.Spouse != nil {
+		const prefix string = ",\"spouse\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Spouse).MarshalEasyJSON(out)
+	}
+	if len(in.Toys) != 0 {
+		const prefix string = ",\"toys\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.Toys).MarshalEasyJSON(out)
+	}
+	if in.Parent != nil {
+		const prefix string = ",\"parent\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Parent).MarshalEasyJSON(out)
+	}
+	if len(in.PlayGroups) != 0 {
+		const prefix string = ",\"play_groups\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.PlayGroups).MarshalEasyJSON(out)
+	}
+	if len(in.Friends) != 0 {
+		const prefix string = ",\"friends\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.Friends).MarshalEasyJSON(out)
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp24(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp24(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp25(in *jlexer.Lexer, out *PetListViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PetListViews, 0, 8)
+			} else {
+				*out = PetListViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v58 *PetListView
+			if in.IsNull() {
+				in.Skip()
+				v58 = nil
+			} else {
+				if v58 == nil {
+					v58 = new(PetListView)
+				}
+				(*v58).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v58)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp25(out *jwriter.Writer, in PetListViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v59, v60 := range in {
+			if v59 > 0 {
+				out.RawByte(',')
+			}
+			if v60 == nil {
+				out.RawString("null")
+			} else {
+				(*v60).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetListViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp25(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetListViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp25(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp26(in *jlexer.Lexer, out *PetListView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "name":
+			out.Name = string(in.String())
+		case "sex":
+			out.Sex = pet.Sex(in.String())
+		case "chip":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.Chip).UnmarshalText(data))
+			}
+		case "badge":
+			if in.IsNull() {
+				in.Skip()
+				out.Badge = nil
+			} else {
+				if out.Badge == nil {
+					out.Badge = new(BadgeWithPetListView)
+				}
+				(*out.Badge).UnmarshalEasyJSON(in)
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp26(out *jwriter.Writer, in PetListView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if in.Sex != "" {
+		const prefix string = ",\"sex\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Sex))
+	}
+	if true {
+		const prefix string = ",\"chip\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.RawText((in.Chip).MarshalText())
+	}
+	if in.Badge != nil {
+		const prefix string = ",\"badge\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Badge).MarshalEasyJSON(out)
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetListView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp26(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetListView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp26(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp27(in *jlexer.Lexer, out *PetListAndPetReadViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PetListAndPetReadViews, 0, 8)
+			} else {
+				*out = PetListAndPetReadViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v61 *PetListAndPetReadView
+			if in.IsNull() {
+				in.Skip()
+				v61 = nil
+			} else {
+				if v61 == nil {
+					v61 = new(PetListAndPetReadView)
+				}
+				(*v61).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v61)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp27(out *jwriter.Writer, in PetListAndPetReadViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v62, v63 := range in {
+			if v62 > 0 {
+				out.RawByte(',')
+			}
+			if v63 == nil {
+				out.RawString("null")
+			} else {
+				(*v63).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetListAndPetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp27(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetListAndPetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp27(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp28(in *jlexer.Lexer, out *PetListAndPetReadView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "height":
+			out.Height = int(in.Int())
+		case "weight":
+			out.Weight = float64(in.Float64())
+		case "castrated":
+			out.Castrated = bool(in.Bool())
+		case "name":
+			out.Name = string(in.String())
+		case "birthday":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Birthday).UnmarshalJSON(data))
+			}
+		case "nicknames":
+			if in.IsNull() {
+				in.Skip()
+				out.Nicknames = nil
+			} else {
+				in.Delim('[')
+				if out.Nicknames == nil {
+					if !in.IsDelim(']') {
+						out.Nicknames = make([]string, 0, 4)
+					} else {
+						out.Nicknames = []string{}
+					}
+				} else {
+					out.Nicknames = (out.Nicknames)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v64 string
+					v64 = string(in.String())
+					out.Nicknames = append(out.Nicknames, v64)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "sex":
+			out.Sex = pet.Sex(in.String())
+		case "chip":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.Chip).UnmarshalText(data))
+			}
+		case "badge":
+			if in.IsNull() {
+				in.Skip()
+				out.Badge = nil
+			} else {
+				if out.Badge == nil {
+					out.Badge = new(BadgeWithPetListAndPetReadView)
+				}
+				(*out.Badge).UnmarshalEasyJSON(in)
+			}
+		case "protege":
+			if in.IsNull() {
+				in.Skip()
+				out.Protege = nil
+			} else {
+				if out.Protege == nil {
+					out.Protege = new(PetListAndPetReadView)
+				}
+				(*out.Protege).UnmarshalEasyJSON(in)
+			}
+		case "spouse":
+			if in.IsNull() {
+				in.Skip()
+				out.Spouse = nil
+			} else {
+				if out.Spouse == nil {
+					out.Spouse = new(PetListAndPetReadView)
+				}
+				(*out.Spouse).UnmarshalEasyJSON(in)
+			}
+		case "toys":
+			(out.Toys).UnmarshalEasyJSON(in)
+		case "parent":
+			if in.IsNull() {
+				in.Skip()
+				out.Parent = nil
+			} else {
+				if out.Parent == nil {
+					out.Parent = new(PetListAndPetReadView)
+				}
+				(*out.Parent).UnmarshalEasyJSON(in)
+			}
+		case "play_groups":
+			(out.PlayGroups).UnmarshalEasyJSON(in)
+		case "friends":
+			(out.Friends).UnmarshalEasyJSON(in)
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp28(out *jwriter.Writer, in PetListAndPetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Height != 0 {
+		const prefix string = ",\"height\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.Height))
+	}
+	if in.Weight != 0 {
+		const prefix string = ",\"weight\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Float64(float64(in.Weight))
+	}
+	if in.Castrated {
+		const prefix string = ",\"castrated\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.Castrated))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if true {
+		const prefix string = ",\"birthday\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.Birthday).MarshalJSON())
+	}
+	if len(in.Nicknames) != 0 {
+		const prefix string = ",\"nicknames\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v65, v66 := range in.Nicknames {
+				if v65 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v66))
+			}
+			out.RawByte(']')
+		}
+	}
+	if in.Sex != "" {
+		const prefix string = ",\"sex\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Sex))
+	}
+	if true {
+		const prefix string = ",\"chip\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.RawText((in.Chip).MarshalText())
+	}
+	if in.Badge != nil {
+		const prefix string = ",\"badge\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Badge).MarshalEasyJSON(out)
+	}
+	if in.Protege != nil {
+		const prefix string = ",\"protege\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Protege).MarshalEasyJSON(out)
+	}
+	if in.Spouse != nil {
+		const prefix string = ",\"spouse\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Spouse).MarshalEasyJSON(out)
+	}
+	if len(in.Toys) != 0 {
+		const prefix string = ",\"toys\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.Toys).MarshalEasyJSON(out)
+	}
+	if in.Parent != nil {
+		const prefix string = ",\"parent\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Parent).MarshalEasyJSON(out)
+	}
+	if len(in.PlayGroups) != 0 {
+		const prefix string = ",\"play_groups\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.PlayGroups).MarshalEasyJSON(out)
+	}
+	if len(in.Friends) != 0 {
+		const prefix string = ",\"friends\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.Friends).MarshalEasyJSON(out)
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetListAndPetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp28(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetListAndPetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp28(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp29(in *jlexer.Lexer, out *PetCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1695,9 +3556,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer
 						*out.Nicknames = (*out.Nicknames)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v34 string
-						v34 = string(in.String())
-						*out.Nicknames = append(*out.Nicknames, v34)
+						var v67 string
+						v67 = string(in.String())
+						*out.Nicknames = append(*out.Nicknames, v67)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -1781,11 +3642,11 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer
 					out.Toys = (out.Toys)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v35 uuid.UUID
+					var v68 uuid.UUID
 					if data := in.UnsafeBytes(); in.Ok() {
-						in.AddError((v35).UnmarshalText(data))
+						in.AddError((v68).UnmarshalText(data))
 					}
-					out.Toys = append(out.Toys, v35)
+					out.Toys = append(out.Toys, v68)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1816,9 +3677,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer
 					out.Children = (out.Children)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v36 int
-					v36 = int(in.Int())
-					out.Children = append(out.Children, v36)
+					var v69 int
+					v69 = int(in.Int())
+					out.Children = append(out.Children, v69)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1839,9 +3700,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer
 					out.PlayGroups = (out.PlayGroups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v37 int
-					v37 = int(in.Int())
-					out.PlayGroups = append(out.PlayGroups, v37)
+					var v70 int
+					v70 = int(in.Int())
+					out.PlayGroups = append(out.PlayGroups, v70)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1862,9 +3723,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer
 					out.Friends = (out.Friends)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v38 int
-					v38 = int(in.Int())
-					out.Friends = append(out.Friends, v38)
+					var v71 int
+					v71 = int(in.Int())
+					out.Friends = append(out.Friends, v71)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1883,7 +3744,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwriter.Writer, in PetCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp29(out *jwriter.Writer, in PetCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1942,11 +3803,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwrit
 				out.RawString("null")
 			} else {
 				out.RawByte('[')
-				for v39, v40 := range *in.Nicknames {
-					if v39 > 0 {
+				for v72, v73 := range *in.Nicknames {
+					if v72 > 0 {
 						out.RawByte(',')
 					}
-					out.String(string(v40))
+					out.String(string(v73))
 				}
 				out.RawByte(']')
 			}
@@ -2013,11 +3874,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v41, v42 := range in.Toys {
-				if v41 > 0 {
+			for v74, v75 := range in.Toys {
+				if v74 > 0 {
 					out.RawByte(',')
 				}
-				out.RawText((v42).MarshalText())
+				out.RawText((v75).MarshalText())
 			}
 			out.RawByte(']')
 		}
@@ -2038,11 +3899,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v43, v44 := range in.Children {
-				if v43 > 0 {
+			for v76, v77 := range in.Children {
+				if v76 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v44))
+				out.Int(int(v77))
 			}
 			out.RawByte(']')
 		}
@@ -2054,11 +3915,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v45, v46 := range in.PlayGroups {
-				if v45 > 0 {
+			for v78, v79 := range in.PlayGroups {
+				if v78 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v46))
+				out.Int(int(v79))
 			}
 			out.RawByte(']')
 		}
@@ -2070,11 +3931,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwrit
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v47, v48 := range in.Friends {
-				if v47 > 0 {
+			for v80, v81 := range in.Friends {
+				if v80 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v48))
+				out.Int(int(v81))
 			}
 			out.RawByte(']')
 		}
@@ -2084,14 +3945,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwrit
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp29(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp29(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(in *jlexer.Lexer, out *ErrResponse) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp30(in *jlexer.Lexer, out *ErrResponse) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2136,7 +3997,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(out *jwriter.Writer, in ErrResponse) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp30(out *jwriter.Writer, in ErrResponse) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2166,14 +4027,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(out *jwrit
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ErrResponse) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp30(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ErrResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp30(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(in *jlexer.Lexer, out *BadgeViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp31(in *jlexer.Lexer, out *BadgeWithPetReadViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -2182,25 +4043,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(in *jlexer
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(BadgeViews, 0, 8)
+				*out = make(BadgeWithPetReadViews, 0, 8)
 			} else {
-				*out = BadgeViews{}
+				*out = BadgeWithPetReadViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v49 *BadgeView
+			var v82 *BadgeWithPetReadView
 			if in.IsNull() {
 				in.Skip()
-				v49 = nil
+				v82 = nil
 			} else {
-				if v49 == nil {
-					v49 = new(BadgeView)
+				if v82 == nil {
+					v82 = new(BadgeWithPetReadView)
 				}
-				(*v49).UnmarshalEasyJSON(in)
+				(*v82).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v49)
+			*out = append(*out, v82)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -2209,19 +4070,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(out *jwriter.Writer, in BadgeViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp31(out *jwriter.Writer, in BadgeWithPetReadViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v50, v51 := range in {
-			if v50 > 0 {
+		for v83, v84 := range in {
+			if v83 > 0 {
 				out.RawByte(',')
 			}
-			if v51 == nil {
+			if v84 == nil {
 				out.RawString("null")
 			} else {
-				(*v51).MarshalEasyJSON(out)
+				(*v84).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -2229,15 +4090,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(out *jwrit
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v BadgeViews) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(w, v)
+func (v BadgeWithPetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp31(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *BadgeViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(l, v)
+func (v *BadgeWithPetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp31(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(in *jlexer.Lexer, out *BadgeView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp32(in *jlexer.Lexer, out *BadgeWithPetReadView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2276,7 +4137,442 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(out *jwriter.Writer, in BadgeView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp32(out *jwriter.Writer, in BadgeWithPetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Uint32(uint32(in.ID))
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	if in.Material != "" {
+		const prefix string = ",\"material\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Material))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeWithPetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp32(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeWithPetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp32(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp33(in *jlexer.Lexer, out *BadgeWithPetListViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(BadgeWithPetListViews, 0, 8)
+			} else {
+				*out = BadgeWithPetListViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v85 *BadgeWithPetListView
+			if in.IsNull() {
+				in.Skip()
+				v85 = nil
+			} else {
+				if v85 == nil {
+					v85 = new(BadgeWithPetListView)
+				}
+				(*v85).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v85)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp33(out *jwriter.Writer, in BadgeWithPetListViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v86, v87 := range in {
+			if v86 > 0 {
+				out.RawByte(',')
+			}
+			if v87 == nil {
+				out.RawString("null")
+			} else {
+				(*v87).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeWithPetListViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp33(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeWithPetListViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp33(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp34(in *jlexer.Lexer, out *BadgeWithPetListView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = uint32(in.Uint32())
+		case "color":
+			out.Color = badge.Color(in.String())
+		case "material":
+			out.Material = badge.Material(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp34(out *jwriter.Writer, in BadgeWithPetListView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Uint32(uint32(in.ID))
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	if in.Material != "" {
+		const prefix string = ",\"material\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Material))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeWithPetListView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp34(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeWithPetListView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp34(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp35(in *jlexer.Lexer, out *BadgeWithPetListAndPetReadViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(BadgeWithPetListAndPetReadViews, 0, 8)
+			} else {
+				*out = BadgeWithPetListAndPetReadViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v88 *BadgeWithPetListAndPetReadView
+			if in.IsNull() {
+				in.Skip()
+				v88 = nil
+			} else {
+				if v88 == nil {
+					v88 = new(BadgeWithPetListAndPetReadView)
+				}
+				(*v88).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v88)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp35(out *jwriter.Writer, in BadgeWithPetListAndPetReadViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v89, v90 := range in {
+			if v89 > 0 {
+				out.RawByte(',')
+			}
+			if v90 == nil {
+				out.RawString("null")
+			} else {
+				(*v90).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeWithPetListAndPetReadViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp35(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeWithPetListAndPetReadViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp35(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp36(in *jlexer.Lexer, out *BadgeWithPetListAndPetReadView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = uint32(in.Uint32())
+		case "color":
+			out.Color = badge.Color(in.String())
+		case "material":
+			out.Material = badge.Material(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp36(out *jwriter.Writer, in BadgeWithPetListAndPetReadView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Uint32(uint32(in.ID))
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	if in.Material != "" {
+		const prefix string = ",\"material\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Material))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeWithPetListAndPetReadView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp36(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeWithPetListAndPetReadView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp36(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp37(in *jlexer.Lexer, out *BadgeViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(BadgeViews, 0, 8)
+			} else {
+				*out = BadgeViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v91 *BadgeView
+			if in.IsNull() {
+				in.Skip()
+				v91 = nil
+			} else {
+				if v91 == nil {
+					v91 = new(BadgeView)
+				}
+				(*v91).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v91)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp37(out *jwriter.Writer, in BadgeViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v92, v93 := range in {
+			if v92 > 0 {
+				out.RawByte(',')
+			}
+			if v93 == nil {
+				out.RawString("null")
+			} else {
+				(*v93).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp37(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp37(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp38(in *jlexer.Lexer, out *BadgeView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = uint32(in.Uint32())
+		case "color":
+			out.Color = badge.Color(in.String())
+		case "material":
+			out.Material = badge.Material(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp38(out *jwriter.Writer, in BadgeView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2311,14 +4607,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(out *jwrit
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BadgeView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp38(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BadgeView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp38(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(in *jlexer.Lexer, out *BadgeUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp39(in *jlexer.Lexer, out *BadgeUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2381,7 +4677,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(out *jwriter.Writer, in BadgeUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp39(out *jwriter.Writer, in BadgeUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2417,14 +4713,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(out *jwrit
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BadgeUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp39(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BadgeUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp39(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(in *jlexer.Lexer, out *BadgeCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp40(in *jlexer.Lexer, out *BadgeCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2487,7 +4783,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(out *jwriter.Writer, in BadgeCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp40(out *jwriter.Writer, in BadgeCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2523,10 +4819,10 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(out *jwrit
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BadgeCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp40(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BadgeCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp40(l, v)
 }

--- a/internal/pets/ent/http/easyjson.go
+++ b/internal/pets/ent/http/easyjson.go
@@ -23,7 +23,166 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(in *jlexer.Lexer, out *ToyUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(in *jlexer.Lexer, out *ToyViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(ToyViews, 0, 8)
+			} else {
+				*out = ToyViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v1 *ToyView
+			if in.IsNull() {
+				in.Skip()
+				v1 = nil
+			} else {
+				if v1 == nil {
+					v1 = new(ToyView)
+				}
+				(*v1).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v1)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(out *jwriter.Writer, in ToyViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v2, v3 := range in {
+			if v2 > 0 {
+				out.RawByte(',')
+			}
+			if v3 == nil {
+				out.RawString("null")
+			} else {
+				(*v3).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(in *jlexer.Lexer, out *ToyView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.ID).UnmarshalText(data))
+			}
+		case "color":
+			out.Color = toy.Color(in.String())
+		case "material":
+			out.Material = toy.Material(in.String())
+		case "title":
+			out.Title = string(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(out *jwriter.Writer, in ToyView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if true {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.RawText((in.ID).MarshalText())
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	if in.Material != "" {
+		const prefix string = ",\"material\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Material))
+	}
+	if in.Title != "" {
+		const prefix string = ",\"title\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Title))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ToyView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ToyView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(in *jlexer.Lexer, out *ToyUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -96,7 +255,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(in *jlexer.L
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(out *jwriter.Writer, in ToyUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(out *jwriter.Writer, in ToyUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -141,14 +300,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(out *jwriter
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ToyUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ToyUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(in *jlexer.Lexer, out *ToyCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(in *jlexer.Lexer, out *ToyCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -221,7 +380,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(out *jwriter.Writer, in ToyCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(out *jwriter.Writer, in ToyCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -266,14 +425,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ToyCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp1(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ToyCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp1(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(in *jlexer.Lexer, out *Toy36157710Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(in *jlexer.Lexer, out *PlayGroupViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -282,25 +441,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(in *jlexer.
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Toy36157710Views, 0, 8)
+				*out = make(PlayGroupViews, 0, 8)
 			} else {
-				*out = Toy36157710Views{}
+				*out = PlayGroupViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v1 *Toy36157710View
+			var v4 *PlayGroupView
 			if in.IsNull() {
 				in.Skip()
-				v1 = nil
+				v4 = nil
 			} else {
-				if v1 == nil {
-					v1 = new(Toy36157710View)
+				if v4 == nil {
+					v4 = new(PlayGroupView)
 				}
-				(*v1).UnmarshalEasyJSON(in)
+				(*v4).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v1)
+			*out = append(*out, v4)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -309,19 +468,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(out *jwriter.Writer, in Toy36157710Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(out *jwriter.Writer, in PlayGroupViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v2, v3 := range in {
-			if v2 > 0 {
+		for v5, v6 := range in {
+			if v5 > 0 {
 				out.RawByte(',')
 			}
-			if v3 == nil {
+			if v6 == nil {
 				out.RawString("null")
 			} else {
-				(*v3).MarshalEasyJSON(out)
+				(*v6).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -329,15 +488,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(out *jwrite
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Toy36157710Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp2(w, v)
+func (v PlayGroupViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Toy36157710Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp2(l, v)
+func (v *PlayGroupViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(in *jlexer.Lexer, out *Toy36157710View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(in *jlexer.Lexer, out *PlayGroupView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -357,15 +516,13 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(in *jlexer.
 		}
 		switch key {
 		case "id":
-			if data := in.UnsafeBytes(); in.Ok() {
-				in.AddError((out.ID).UnmarshalText(data))
-			}
-		case "color":
-			out.Color = toy.Color(in.String())
-		case "material":
-			out.Material = toy.Material(in.String())
+			out.ID = int(in.Int())
 		case "title":
 			out.Title = string(in.String())
+		case "description":
+			out.Description = string(in.String())
+		case "weekday":
+			out.Weekday = playgroup.Weekday(in.String())
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -380,35 +537,15 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(out *jwriter.Writer, in Toy36157710View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(out *jwriter.Writer, in PlayGroupView) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	if true {
+	if in.ID != 0 {
 		const prefix string = ",\"id\":"
 		first = false
 		out.RawString(prefix[1:])
-		out.RawText((in.ID).MarshalText())
-	}
-	if in.Color != "" {
-		const prefix string = ",\"color\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Color))
-	}
-	if in.Material != "" {
-		const prefix string = ",\"material\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Material))
+		out.Int(int(in.ID))
 	}
 	if in.Title != "" {
 		const prefix string = ",\"title\":"
@@ -420,164 +557,39 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(out *jwrite
 		}
 		out.String(string(in.Title))
 	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Toy36157710View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp3(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Toy36157710View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp3(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(in *jlexer.Lexer, out *PlayGroupUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "title":
-			if in.IsNull() {
-				in.Skip()
-				out.Title = nil
-			} else {
-				if out.Title == nil {
-					out.Title = new(string)
-				}
-				*out.Title = string(in.String())
-			}
-		case "description":
-			if in.IsNull() {
-				in.Skip()
-				out.Description = nil
-			} else {
-				if out.Description == nil {
-					out.Description = new(string)
-				}
-				*out.Description = string(in.String())
-			}
-		case "weekday":
-			if in.IsNull() {
-				in.Skip()
-				out.Weekday = nil
-			} else {
-				if out.Weekday == nil {
-					out.Weekday = new(playgroup.Weekday)
-				}
-				*out.Weekday = playgroup.Weekday(in.String())
-			}
-		case "participants":
-			if in.IsNull() {
-				in.Skip()
-				out.Participants = nil
-			} else {
-				in.Delim('[')
-				if out.Participants == nil {
-					if !in.IsDelim(']') {
-						out.Participants = make([]int, 0, 8)
-					} else {
-						out.Participants = []int{}
-					}
-				} else {
-					out.Participants = (out.Participants)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v4 int
-					v4 = int(in.Int())
-					out.Participants = append(out.Participants, v4)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(out *jwriter.Writer, in PlayGroupUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"title\":"
-		out.RawString(prefix[1:])
-		if in.Title == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Title))
-		}
-	}
-	{
+	if in.Description != "" {
 		const prefix string = ",\"description\":"
-		out.RawString(prefix)
-		if in.Description == nil {
-			out.RawString("null")
+		if first {
+			first = false
+			out.RawString(prefix[1:])
 		} else {
-			out.String(string(*in.Description))
+			out.RawString(prefix)
 		}
+		out.String(string(in.Description))
 	}
-	{
+	if in.Weekday != "" {
 		const prefix string = ",\"weekday\":"
-		out.RawString(prefix)
-		if in.Weekday == nil {
-			out.RawString("null")
+		if first {
+			first = false
+			out.RawString(prefix[1:])
 		} else {
-			out.String(string(*in.Weekday))
+			out.RawString(prefix)
 		}
-	}
-	{
-		const prefix string = ",\"participants\":"
-		out.RawString(prefix)
-		if in.Participants == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v5, v6 := range in.Participants {
-				if v5 > 0 {
-					out.RawByte(',')
-				}
-				out.Int(int(v6))
-			}
-			out.RawByte(']')
-		}
+		out.String(string(in.Weekday))
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PlayGroupUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp4(w, v)
+func (v PlayGroupView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PlayGroupUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp4(l, v)
+func (v *PlayGroupView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(in *jlexer.Lexer, out *PlayGroupCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.Lexer, out *PlayGroupUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -663,7 +675,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(out *jwriter.Writer, in PlayGroupCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(out *jwriter.Writer, in PlayGroupUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -714,15 +726,160 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(out *jwrite
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PlayGroupUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PlayGroupUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.Lexer, out *PlayGroupCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "title":
+			if in.IsNull() {
+				in.Skip()
+				out.Title = nil
+			} else {
+				if out.Title == nil {
+					out.Title = new(string)
+				}
+				*out.Title = string(in.String())
+			}
+		case "description":
+			if in.IsNull() {
+				in.Skip()
+				out.Description = nil
+			} else {
+				if out.Description == nil {
+					out.Description = new(string)
+				}
+				*out.Description = string(in.String())
+			}
+		case "weekday":
+			if in.IsNull() {
+				in.Skip()
+				out.Weekday = nil
+			} else {
+				if out.Weekday == nil {
+					out.Weekday = new(playgroup.Weekday)
+				}
+				*out.Weekday = playgroup.Weekday(in.String())
+			}
+		case "participants":
+			if in.IsNull() {
+				in.Skip()
+				out.Participants = nil
+			} else {
+				in.Delim('[')
+				if out.Participants == nil {
+					if !in.IsDelim(']') {
+						out.Participants = make([]int, 0, 8)
+					} else {
+						out.Participants = []int{}
+					}
+				} else {
+					out.Participants = (out.Participants)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v10 int
+					v10 = int(in.Int())
+					out.Participants = append(out.Participants, v10)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(out *jwriter.Writer, in PlayGroupCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"title\":"
+		out.RawString(prefix[1:])
+		if in.Title == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Title))
+		}
+	}
+	{
+		const prefix string = ",\"description\":"
+		out.RawString(prefix)
+		if in.Description == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Description))
+		}
+	}
+	{
+		const prefix string = ",\"weekday\":"
+		out.RawString(prefix)
+		if in.Weekday == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Weekday))
+		}
+	}
+	{
+		const prefix string = ",\"participants\":"
+		out.RawString(prefix)
+		if in.Participants == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v11, v12 := range in.Participants {
+				if v11 > 0 {
+					out.RawByte(',')
+				}
+				out.Int(int(v12))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PlayGroupCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp5(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PlayGroupCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp5(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.Lexer, out *PlayGroup3432834655Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.Lexer, out *PetViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -731,25 +888,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(PlayGroup3432834655Views, 0, 8)
+				*out = make(PetViews, 0, 8)
 			} else {
-				*out = PlayGroup3432834655Views{}
+				*out = PetViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v10 *PlayGroup3432834655View
+			var v13 *PetView
 			if in.IsNull() {
 				in.Skip()
-				v10 = nil
+				v13 = nil
 			} else {
-				if v10 == nil {
-					v10 = new(PlayGroup3432834655View)
+				if v13 == nil {
+					v13 = new(PetView)
 				}
-				(*v10).UnmarshalEasyJSON(in)
+				(*v13).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v10)
+			*out = append(*out, v13)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -758,19 +915,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(out *jwriter.Writer, in PlayGroup3432834655Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwriter.Writer, in PetViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v11, v12 := range in {
-			if v11 > 0 {
+		for v14, v15 := range in {
+			if v14 > 0 {
 				out.RawByte(',')
 			}
-			if v12 == nil {
+			if v15 == nil {
 				out.RawString("null")
 			} else {
-				(*v12).MarshalEasyJSON(out)
+				(*v15).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -778,15 +935,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(out *jwrite
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PlayGroup3432834655Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp6(w, v)
+func (v PetViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PlayGroup3432834655Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp6(l, v)
+func (v *PetViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.Lexer, out *PlayGroup3432834655View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.Lexer, out *PetView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -807,12 +964,47 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.
 		switch key {
 		case "id":
 			out.ID = int(in.Int())
-		case "title":
-			out.Title = string(in.String())
-		case "description":
-			out.Description = string(in.String())
-		case "weekday":
-			out.Weekday = playgroup.Weekday(in.String())
+		case "height":
+			out.Height = int(in.Int())
+		case "weight":
+			out.Weight = float64(in.Float64())
+		case "castrated":
+			out.Castrated = bool(in.Bool())
+		case "name":
+			out.Name = string(in.String())
+		case "birthday":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Birthday).UnmarshalJSON(data))
+			}
+		case "nicknames":
+			if in.IsNull() {
+				in.Skip()
+				out.Nicknames = nil
+			} else {
+				in.Delim('[')
+				if out.Nicknames == nil {
+					if !in.IsDelim(']') {
+						out.Nicknames = make([]string, 0, 4)
+					} else {
+						out.Nicknames = []string{}
+					}
+				} else {
+					out.Nicknames = (out.Nicknames)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v16 string
+					v16 = string(in.String())
+					out.Nicknames = append(out.Nicknames, v16)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "sex":
+			out.Sex = pet.Sex(in.String())
+		case "chip":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.Chip).UnmarshalText(data))
+			}
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -827,7 +1019,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(out *jwriter.Writer, in PlayGroup3432834655View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwriter.Writer, in PetView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -837,49 +1029,108 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(out *jwrite
 		out.RawString(prefix[1:])
 		out.Int(int(in.ID))
 	}
-	if in.Title != "" {
-		const prefix string = ",\"title\":"
+	if in.Height != 0 {
+		const prefix string = ",\"height\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Title))
+		out.Int(int(in.Height))
 	}
-	if in.Description != "" {
-		const prefix string = ",\"description\":"
+	if in.Weight != 0 {
+		const prefix string = ",\"weight\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Description))
+		out.Float64(float64(in.Weight))
 	}
-	if in.Weekday != "" {
-		const prefix string = ",\"weekday\":"
+	if in.Castrated {
+		const prefix string = ",\"castrated\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Weekday))
+		out.Bool(bool(in.Castrated))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if true {
+		const prefix string = ",\"birthday\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.Birthday).MarshalJSON())
+	}
+	if len(in.Nicknames) != 0 {
+		const prefix string = ",\"nicknames\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v17, v18 := range in.Nicknames {
+				if v17 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v18))
+			}
+			out.RawByte(']')
+		}
+	}
+	if in.Sex != "" {
+		const prefix string = ",\"sex\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Sex))
+	}
+	if true {
+		const prefix string = ",\"chip\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.RawText((in.Chip).MarshalText())
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PlayGroup3432834655View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp7(w, v)
+func (v PetView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PlayGroup3432834655View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp7(l, v)
+func (v *PetView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.Lexer, out *PetUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer.Lexer, out *PetUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -973,9 +1224,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 						*out.Nicknames = (*out.Nicknames)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v13 string
-						v13 = string(in.String())
-						*out.Nicknames = append(*out.Nicknames, v13)
+						var v19 string
+						v19 = string(in.String())
+						*out.Nicknames = append(*out.Nicknames, v19)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -1049,11 +1300,11 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 					out.Toys = (out.Toys)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v14 uuid.UUID
+					var v20 uuid.UUID
 					if data := in.UnsafeBytes(); in.Ok() {
-						in.AddError((v14).UnmarshalText(data))
+						in.AddError((v20).UnmarshalText(data))
 					}
-					out.Toys = append(out.Toys, v14)
+					out.Toys = append(out.Toys, v20)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1084,9 +1335,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 					out.Children = (out.Children)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v15 int
-					v15 = int(in.Int())
-					out.Children = append(out.Children, v15)
+					var v21 int
+					v21 = int(in.Int())
+					out.Children = append(out.Children, v21)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1107,9 +1358,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 					out.PlayGroups = (out.PlayGroups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v16 int
-					v16 = int(in.Int())
-					out.PlayGroups = append(out.PlayGroups, v16)
+					var v22 int
+					v22 = int(in.Int())
+					out.PlayGroups = append(out.PlayGroups, v22)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1130,9 +1381,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 					out.Friends = (out.Friends)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v17 int
-					v17 = int(in.Int())
-					out.Friends = append(out.Friends, v17)
+					var v23 int
+					v23 = int(in.Int())
+					out.Friends = append(out.Friends, v23)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1151,7 +1402,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwriter.Writer, in PetUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwriter.Writer, in PetUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1210,11 +1461,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwrite
 				out.RawString("null")
 			} else {
 				out.RawByte('[')
-				for v18, v19 := range *in.Nicknames {
-					if v18 > 0 {
+				for v24, v25 := range *in.Nicknames {
+					if v24 > 0 {
 						out.RawByte(',')
 					}
-					out.String(string(v19))
+					out.String(string(v25))
 				}
 				out.RawByte(']')
 			}
@@ -1272,11 +1523,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v20, v21 := range in.Toys {
-				if v20 > 0 {
+			for v26, v27 := range in.Toys {
+				if v26 > 0 {
 					out.RawByte(',')
 				}
-				out.RawText((v21).MarshalText())
+				out.RawText((v27).MarshalText())
 			}
 			out.RawByte(']')
 		}
@@ -1297,11 +1548,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v22, v23 := range in.Children {
-				if v22 > 0 {
+			for v28, v29 := range in.Children {
+				if v28 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v23))
+				out.Int(int(v29))
 			}
 			out.RawByte(']')
 		}
@@ -1313,11 +1564,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v24, v25 := range in.PlayGroups {
-				if v24 > 0 {
+			for v30, v31 := range in.PlayGroups {
+				if v30 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v25))
+				out.Int(int(v31))
 			}
 			out.RawByte(']')
 		}
@@ -1329,11 +1580,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v26, v27 := range in.Friends {
-				if v26 > 0 {
+			for v32, v33 := range in.Friends {
+				if v32 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v27))
+				out.Int(int(v33))
 			}
 			out.RawByte(']')
 		}
@@ -1343,14 +1594,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp8(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp8(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.Lexer, out *PetCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer.Lexer, out *PetCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1444,9 +1695,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 						*out.Nicknames = (*out.Nicknames)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v28 string
-						v28 = string(in.String())
-						*out.Nicknames = append(*out.Nicknames, v28)
+						var v34 string
+						v34 = string(in.String())
+						*out.Nicknames = append(*out.Nicknames, v34)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -1530,11 +1781,11 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 					out.Toys = (out.Toys)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v29 uuid.UUID
+					var v35 uuid.UUID
 					if data := in.UnsafeBytes(); in.Ok() {
-						in.AddError((v29).UnmarshalText(data))
+						in.AddError((v35).UnmarshalText(data))
 					}
-					out.Toys = append(out.Toys, v29)
+					out.Toys = append(out.Toys, v35)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1565,9 +1816,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 					out.Children = (out.Children)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v30 int
-					v30 = int(in.Int())
-					out.Children = append(out.Children, v30)
+					var v36 int
+					v36 = int(in.Int())
+					out.Children = append(out.Children, v36)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1588,9 +1839,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 					out.PlayGroups = (out.PlayGroups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v31 int
-					v31 = int(in.Int())
-					out.PlayGroups = append(out.PlayGroups, v31)
+					var v37 int
+					v37 = int(in.Int())
+					out.PlayGroups = append(out.PlayGroups, v37)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1611,9 +1862,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 					out.Friends = (out.Friends)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v32 int
-					v32 = int(in.Int())
-					out.Friends = append(out.Friends, v32)
+					var v38 int
+					v38 = int(in.Int())
+					out.Friends = append(out.Friends, v38)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1632,7 +1883,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwriter.Writer, in PetCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwriter.Writer, in PetCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1691,11 +1942,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 				out.RawString("null")
 			} else {
 				out.RawByte('[')
-				for v33, v34 := range *in.Nicknames {
-					if v33 > 0 {
+				for v39, v40 := range *in.Nicknames {
+					if v39 > 0 {
 						out.RawByte(',')
 					}
-					out.String(string(v34))
+					out.String(string(v40))
 				}
 				out.RawByte(']')
 			}
@@ -1762,11 +2013,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v35, v36 := range in.Toys {
-				if v35 > 0 {
+			for v41, v42 := range in.Toys {
+				if v41 > 0 {
 					out.RawByte(',')
 				}
-				out.RawText((v36).MarshalText())
+				out.RawText((v42).MarshalText())
 			}
 			out.RawByte(']')
 		}
@@ -1787,11 +2038,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v37, v38 := range in.Children {
-				if v37 > 0 {
+			for v43, v44 := range in.Children {
+				if v43 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v38))
+				out.Int(int(v44))
 			}
 			out.RawByte(']')
 		}
@@ -1803,11 +2054,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v39, v40 := range in.PlayGroups {
-				if v39 > 0 {
+			for v45, v46 := range in.PlayGroups {
+				if v45 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v40))
+				out.Int(int(v46))
 			}
 			out.RawByte(']')
 		}
@@ -1819,11 +2070,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v41, v42 := range in.Friends {
-				if v41 > 0 {
+			for v47, v48 := range in.Friends {
+				if v47 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v42))
+				out.Int(int(v48))
 			}
 			out.RawByte(']')
 		}
@@ -1833,811 +2084,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(out *jwrite
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp9(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp9(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(in *jlexer.Lexer, out *Pet45794832Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Pet45794832Views, 0, 8)
-			} else {
-				*out = Pet45794832Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v43 *Pet45794832View
-			if in.IsNull() {
-				in.Skip()
-				v43 = nil
-			} else {
-				if v43 == nil {
-					v43 = new(Pet45794832View)
-				}
-				(*v43).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v43)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(out *jwriter.Writer, in Pet45794832Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v44, v45 := range in {
-			if v44 > 0 {
-				out.RawByte(',')
-			}
-			if v45 == nil {
-				out.RawString("null")
-			} else {
-				(*v45).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet45794832Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp10(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet45794832Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp10(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(in *jlexer.Lexer, out *Pet45794832View) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			out.ID = int(in.Int())
-		case "name":
-			out.Name = string(in.String())
-		case "sex":
-			out.Sex = pet.Sex(in.String())
-		case "chip":
-			if data := in.UnsafeBytes(); in.Ok() {
-				in.AddError((out.Chip).UnmarshalText(data))
-			}
-		case "badge":
-			if in.IsNull() {
-				in.Skip()
-				out.Badge = nil
-			} else {
-				if out.Badge == nil {
-					out.Badge = new(Badge2492344257View)
-				}
-				(*out.Badge).UnmarshalEasyJSON(in)
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(out *jwriter.Writer, in Pet45794832View) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.ID != 0 {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Int(int(in.ID))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
-	}
-	if in.Sex != "" {
-		const prefix string = ",\"sex\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Sex))
-	}
-	if true {
-		const prefix string = ",\"chip\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.RawText((in.Chip).MarshalText())
-	}
-	if in.Badge != nil {
-		const prefix string = ",\"badge\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(*in.Badge).MarshalEasyJSON(out)
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet45794832View) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp11(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet45794832View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp11(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(in *jlexer.Lexer, out *Pet340207500Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Pet340207500Views, 0, 8)
-			} else {
-				*out = Pet340207500Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v46 *Pet340207500View
-			if in.IsNull() {
-				in.Skip()
-				v46 = nil
-			} else {
-				if v46 == nil {
-					v46 = new(Pet340207500View)
-				}
-				(*v46).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v46)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(out *jwriter.Writer, in Pet340207500Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v47, v48 := range in {
-			if v47 > 0 {
-				out.RawByte(',')
-			}
-			if v48 == nil {
-				out.RawString("null")
-			} else {
-				(*v48).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet340207500Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet340207500Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(in *jlexer.Lexer, out *Pet340207500View) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			out.ID = int(in.Int())
-		case "height":
-			out.Height = int(in.Int())
-		case "weight":
-			out.Weight = float64(in.Float64())
-		case "castrated":
-			out.Castrated = bool(in.Bool())
-		case "name":
-			out.Name = string(in.String())
-		case "birthday":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Birthday).UnmarshalJSON(data))
-			}
-		case "nicknames":
-			if in.IsNull() {
-				in.Skip()
-				out.Nicknames = nil
-			} else {
-				in.Delim('[')
-				if out.Nicknames == nil {
-					if !in.IsDelim(']') {
-						out.Nicknames = make([]string, 0, 4)
-					} else {
-						out.Nicknames = []string{}
-					}
-				} else {
-					out.Nicknames = (out.Nicknames)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v49 string
-					v49 = string(in.String())
-					out.Nicknames = append(out.Nicknames, v49)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "sex":
-			out.Sex = pet.Sex(in.String())
-		case "chip":
-			if data := in.UnsafeBytes(); in.Ok() {
-				in.AddError((out.Chip).UnmarshalText(data))
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(out *jwriter.Writer, in Pet340207500View) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.ID != 0 {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Int(int(in.ID))
-	}
-	if in.Height != 0 {
-		const prefix string = ",\"height\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.Height))
-	}
-	if in.Weight != 0 {
-		const prefix string = ",\"weight\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Float64(float64(in.Weight))
-	}
-	if in.Castrated {
-		const prefix string = ",\"castrated\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Bool(bool(in.Castrated))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
-	}
-	if true {
-		const prefix string = ",\"birthday\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Raw((in.Birthday).MarshalJSON())
-	}
-	if len(in.Nicknames) != 0 {
-		const prefix string = ",\"nicknames\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v50, v51 := range in.Nicknames {
-				if v50 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v51))
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.Sex != "" {
-		const prefix string = ",\"sex\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Sex))
-	}
-	if true {
-		const prefix string = ",\"chip\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.RawText((in.Chip).MarshalText())
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet340207500View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet340207500View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(in *jlexer.Lexer, out *Pet3217017920Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Pet3217017920Views, 0, 8)
-			} else {
-				*out = Pet3217017920Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v52 *Pet3217017920View
-			if in.IsNull() {
-				in.Skip()
-				v52 = nil
-			} else {
-				if v52 == nil {
-					v52 = new(Pet3217017920View)
-				}
-				(*v52).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v52)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(out *jwriter.Writer, in Pet3217017920Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v53, v54 := range in {
-			if v53 > 0 {
-				out.RawByte(',')
-			}
-			if v54 == nil {
-				out.RawString("null")
-			} else {
-				(*v54).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet3217017920Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet3217017920Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(in *jlexer.Lexer, out *Pet3217017920View) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			out.ID = int(in.Int())
-		case "height":
-			out.Height = int(in.Int())
-		case "weight":
-			out.Weight = float64(in.Float64())
-		case "castrated":
-			out.Castrated = bool(in.Bool())
-		case "name":
-			out.Name = string(in.String())
-		case "birthday":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Birthday).UnmarshalJSON(data))
-			}
-		case "nicknames":
-			if in.IsNull() {
-				in.Skip()
-				out.Nicknames = nil
-			} else {
-				in.Delim('[')
-				if out.Nicknames == nil {
-					if !in.IsDelim(']') {
-						out.Nicknames = make([]string, 0, 4)
-					} else {
-						out.Nicknames = []string{}
-					}
-				} else {
-					out.Nicknames = (out.Nicknames)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v55 string
-					v55 = string(in.String())
-					out.Nicknames = append(out.Nicknames, v55)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "sex":
-			out.Sex = pet.Sex(in.String())
-		case "chip":
-			if data := in.UnsafeBytes(); in.Ok() {
-				in.AddError((out.Chip).UnmarshalText(data))
-			}
-		case "badge":
-			if in.IsNull() {
-				in.Skip()
-				out.Badge = nil
-			} else {
-				if out.Badge == nil {
-					out.Badge = new(Badge2492344257View)
-				}
-				(*out.Badge).UnmarshalEasyJSON(in)
-			}
-		case "protege":
-			if in.IsNull() {
-				in.Skip()
-				out.Protege = nil
-			} else {
-				if out.Protege == nil {
-					out.Protege = new(Pet340207500View)
-				}
-				(*out.Protege).UnmarshalEasyJSON(in)
-			}
-		case "spouse":
-			if in.IsNull() {
-				in.Skip()
-				out.Spouse = nil
-			} else {
-				if out.Spouse == nil {
-					out.Spouse = new(Pet340207500View)
-				}
-				(*out.Spouse).UnmarshalEasyJSON(in)
-			}
-		case "toys":
-			(out.Toys).UnmarshalEasyJSON(in)
-		case "parent":
-			if in.IsNull() {
-				in.Skip()
-				out.Parent = nil
-			} else {
-				if out.Parent == nil {
-					out.Parent = new(Pet340207500View)
-				}
-				(*out.Parent).UnmarshalEasyJSON(in)
-			}
-		case "play_groups":
-			(out.PlayGroups).UnmarshalEasyJSON(in)
-		case "friends":
-			(out.Friends).UnmarshalEasyJSON(in)
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(out *jwriter.Writer, in Pet3217017920View) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.ID != 0 {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Int(int(in.ID))
-	}
-	if in.Height != 0 {
-		const prefix string = ",\"height\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.Height))
-	}
-	if in.Weight != 0 {
-		const prefix string = ",\"weight\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Float64(float64(in.Weight))
-	}
-	if in.Castrated {
-		const prefix string = ",\"castrated\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Bool(bool(in.Castrated))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
-	}
-	if true {
-		const prefix string = ",\"birthday\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Raw((in.Birthday).MarshalJSON())
-	}
-	if len(in.Nicknames) != 0 {
-		const prefix string = ",\"nicknames\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v56, v57 := range in.Nicknames {
-				if v56 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v57))
-			}
-			out.RawByte(']')
-		}
-	}
-	if in.Sex != "" {
-		const prefix string = ",\"sex\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Sex))
-	}
-	if true {
-		const prefix string = ",\"chip\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.RawText((in.Chip).MarshalText())
-	}
-	if in.Badge != nil {
-		const prefix string = ",\"badge\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(*in.Badge).MarshalEasyJSON(out)
-	}
-	if in.Protege != nil {
-		const prefix string = ",\"protege\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(*in.Protege).MarshalEasyJSON(out)
-	}
-	if in.Spouse != nil {
-		const prefix string = ",\"spouse\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(*in.Spouse).MarshalEasyJSON(out)
-	}
-	if len(in.Toys) != 0 {
-		const prefix string = ",\"toys\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(in.Toys).MarshalEasyJSON(out)
-	}
-	if in.Parent != nil {
-		const prefix string = ",\"parent\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(*in.Parent).MarshalEasyJSON(out)
-	}
-	if len(in.PlayGroups) != 0 {
-		const prefix string = ",\"play_groups\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(in.PlayGroups).MarshalEasyJSON(out)
-	}
-	if len(in.Friends) != 0 {
-		const prefix string = ",\"friends\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(in.Friends).MarshalEasyJSON(out)
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet3217017920View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet3217017920View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(in *jlexer.Lexer, out *ErrResponse) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(in *jlexer.Lexer, out *ErrResponse) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2682,7 +2136,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(out *jwriter.Writer, in ErrResponse) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(out *jwriter.Writer, in ErrResponse) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2712,226 +2166,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(out *jwrit
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ErrResponse) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp12(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ErrResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp12(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp17(in *jlexer.Lexer, out *BadgeUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "color":
-			if in.IsNull() {
-				in.Skip()
-				out.Color = nil
-			} else {
-				if out.Color == nil {
-					out.Color = new(badge.Color)
-				}
-				*out.Color = badge.Color(in.String())
-			}
-		case "material":
-			if in.IsNull() {
-				in.Skip()
-				out.Material = nil
-			} else {
-				if out.Material == nil {
-					out.Material = new(badge.Material)
-				}
-				*out.Material = badge.Material(in.String())
-			}
-		case "wearer":
-			if in.IsNull() {
-				in.Skip()
-				out.Wearer = nil
-			} else {
-				if out.Wearer == nil {
-					out.Wearer = new(int)
-				}
-				*out.Wearer = int(in.Int())
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp17(out *jwriter.Writer, in BadgeUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"color\":"
-		out.RawString(prefix[1:])
-		if in.Color == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Color))
-		}
-	}
-	{
-		const prefix string = ",\"material\":"
-		out.RawString(prefix)
-		if in.Material == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Material))
-		}
-	}
-	{
-		const prefix string = ",\"wearer\":"
-		out.RawString(prefix)
-		if in.Wearer == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Wearer))
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v BadgeUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp17(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *BadgeUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp17(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp18(in *jlexer.Lexer, out *BadgeCreateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "color":
-			if in.IsNull() {
-				in.Skip()
-				out.Color = nil
-			} else {
-				if out.Color == nil {
-					out.Color = new(badge.Color)
-				}
-				*out.Color = badge.Color(in.String())
-			}
-		case "material":
-			if in.IsNull() {
-				in.Skip()
-				out.Material = nil
-			} else {
-				if out.Material == nil {
-					out.Material = new(badge.Material)
-				}
-				*out.Material = badge.Material(in.String())
-			}
-		case "wearer":
-			if in.IsNull() {
-				in.Skip()
-				out.Wearer = nil
-			} else {
-				if out.Wearer == nil {
-					out.Wearer = new(int)
-				}
-				*out.Wearer = int(in.Int())
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp18(out *jwriter.Writer, in BadgeCreateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"color\":"
-		out.RawString(prefix[1:])
-		if in.Color == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Color))
-		}
-	}
-	{
-		const prefix string = ",\"material\":"
-		out.RawString(prefix)
-		if in.Material == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Material))
-		}
-	}
-	{
-		const prefix string = ",\"wearer\":"
-		out.RawString(prefix)
-		if in.Wearer == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Wearer))
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v BadgeCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp18(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *BadgeCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp18(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp19(in *jlexer.Lexer, out *Badge2492344257Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(in *jlexer.Lexer, out *BadgeViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -2940,25 +2182,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp19(in *jlexer
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Badge2492344257Views, 0, 8)
+				*out = make(BadgeViews, 0, 8)
 			} else {
-				*out = Badge2492344257Views{}
+				*out = BadgeViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v58 *Badge2492344257View
+			var v49 *BadgeView
 			if in.IsNull() {
 				in.Skip()
-				v58 = nil
+				v49 = nil
 			} else {
-				if v58 == nil {
-					v58 = new(Badge2492344257View)
+				if v49 == nil {
+					v49 = new(BadgeView)
 				}
-				(*v58).UnmarshalEasyJSON(in)
+				(*v49).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v58)
+			*out = append(*out, v49)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -2967,19 +2209,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp19(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp19(out *jwriter.Writer, in Badge2492344257Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(out *jwriter.Writer, in BadgeViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v59, v60 := range in {
-			if v59 > 0 {
+		for v50, v51 := range in {
+			if v50 > 0 {
 				out.RawByte(',')
 			}
-			if v60 == nil {
+			if v51 == nil {
 				out.RawString("null")
 			} else {
-				(*v60).MarshalEasyJSON(out)
+				(*v51).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -2987,15 +2229,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp19(out *jwrit
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Badge2492344257Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp19(w, v)
+func (v BadgeViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp13(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Badge2492344257Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp19(l, v)
+func (v *BadgeViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp13(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp20(in *jlexer.Lexer, out *Badge2492344257View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(in *jlexer.Lexer, out *BadgeView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3034,7 +2276,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp20(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp20(out *jwriter.Writer, in Badge2492344257View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(out *jwriter.Writer, in BadgeView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3068,11 +2310,223 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp20(out *jwrit
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Badge2492344257View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp20(w, v)
+func (v BadgeView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp14(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Badge2492344257View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp20(l, v)
+func (v *BadgeView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp14(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(in *jlexer.Lexer, out *BadgeUpdateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "color":
+			if in.IsNull() {
+				in.Skip()
+				out.Color = nil
+			} else {
+				if out.Color == nil {
+					out.Color = new(badge.Color)
+				}
+				*out.Color = badge.Color(in.String())
+			}
+		case "material":
+			if in.IsNull() {
+				in.Skip()
+				out.Material = nil
+			} else {
+				if out.Material == nil {
+					out.Material = new(badge.Material)
+				}
+				*out.Material = badge.Material(in.String())
+			}
+		case "wearer":
+			if in.IsNull() {
+				in.Skip()
+				out.Wearer = nil
+			} else {
+				if out.Wearer == nil {
+					out.Wearer = new(int)
+				}
+				*out.Wearer = int(in.Int())
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(out *jwriter.Writer, in BadgeUpdateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"color\":"
+		out.RawString(prefix[1:])
+		if in.Color == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Color))
+		}
+	}
+	{
+		const prefix string = ",\"material\":"
+		out.RawString(prefix)
+		if in.Material == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Material))
+		}
+	}
+	{
+		const prefix string = ",\"wearer\":"
+		out.RawString(prefix)
+		if in.Wearer == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Wearer))
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp15(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp15(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(in *jlexer.Lexer, out *BadgeCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "color":
+			if in.IsNull() {
+				in.Skip()
+				out.Color = nil
+			} else {
+				if out.Color == nil {
+					out.Color = new(badge.Color)
+				}
+				*out.Color = badge.Color(in.String())
+			}
+		case "material":
+			if in.IsNull() {
+				in.Skip()
+				out.Material = nil
+			} else {
+				if out.Material == nil {
+					out.Material = new(badge.Material)
+				}
+				*out.Material = badge.Material(in.String())
+			}
+		case "wearer":
+			if in.IsNull() {
+				in.Skip()
+				out.Wearer = nil
+			} else {
+				if out.Wearer == nil {
+					out.Wearer = new(int)
+				}
+				*out.Wearer = int(in.Int())
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(out *jwriter.Writer, in BadgeCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"color\":"
+		out.RawString(prefix[1:])
+		if in.Color == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Color))
+		}
+	}
+	{
+		const prefix string = ",\"material\":"
+		out.RawString(prefix)
+		if in.Material == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Material))
+		}
+	}
+	{
+		const prefix string = ",\"wearer\":"
+		out.RawString(prefix)
+		if in.Wearer == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Wearer))
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v BadgeCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalPetsEntHttp16(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *BadgeCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalPetsEntHttp16(l, v)
 }

--- a/internal/pets/ent/http/list.go
+++ b/internal/pets/ent/http/list.go
@@ -77,7 +77,7 @@ func (h *PetHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetListViews(es), w)
 }
 
 // Read fetches the ent.PlayGroup identified by a given url-parameter from the

--- a/internal/pets/ent/http/list.go
+++ b/internal/pets/ent/http/list.go
@@ -41,7 +41,7 @@ func (h *BadgeHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("badges rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewBadge2492344257Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewBadgeViews(es), w)
 }
 
 // Read fetches the ent.Pet identified by a given url-parameter from the
@@ -77,7 +77,7 @@ func (h *PetHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet45794832Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // Read fetches the ent.PlayGroup identified by a given url-parameter from the
@@ -111,7 +111,7 @@ func (h *PlayGroupHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("play-groups rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPlayGroup3432834655Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPlayGroupViews(es), w)
 }
 
 // Read fetches the ent.Toy identified by a given url-parameter from the
@@ -145,5 +145,5 @@ func (h *ToyHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("toys rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewToy36157710Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewToyViews(es), w)
 }

--- a/internal/pets/ent/http/read.go
+++ b/internal/pets/ent/http/read.go
@@ -10,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	"github.com/masseelch/elk/internal/pets/ent/badge"
-	"github.com/masseelch/elk/internal/pets/ent/pet"
-	"github.com/masseelch/elk/internal/pets/ent/playgroup"
-	"github.com/masseelch/elk/internal/pets/ent/toy"
+	badge "github.com/masseelch/elk/internal/pets/ent/badge"
+	pet "github.com/masseelch/elk/internal/pets/ent/pet"
+	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
+	toy "github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 

--- a/internal/pets/ent/http/read.go
+++ b/internal/pets/ent/http/read.go
@@ -49,7 +49,7 @@ func (h *BadgeHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("badge rendered", zap.Uint32("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewBadge2492344257View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewBadgeView(e), w)
 }
 
 // Read fetches the ent.Pet identified by a given url-parameter from the
@@ -1129,7 +1129,7 @@ func (h *PetHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Read fetches the ent.PlayGroup identified by a given url-parameter from the
@@ -1163,7 +1163,7 @@ func (h *PlayGroupHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("play-group rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPlayGroup3432834655View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPlayGroupView(e), w)
 }
 
 // Read fetches the ent.Toy identified by a given url-parameter from the
@@ -1197,5 +1197,5 @@ func (h *ToyHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("toy rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewToy36157710View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewToyView(e), w)
 }

--- a/internal/pets/ent/http/read.go
+++ b/internal/pets/ent/http/read.go
@@ -10,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	badge "github.com/masseelch/elk/internal/pets/ent/badge"
-	pet "github.com/masseelch/elk/internal/pets/ent/pet"
-	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
-	toy "github.com/masseelch/elk/internal/pets/ent/toy"
+	"github.com/masseelch/elk/internal/pets/ent/badge"
+	"github.com/masseelch/elk/internal/pets/ent/pet"
+	"github.com/masseelch/elk/internal/pets/ent/playgroup"
+	"github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 
@@ -1129,7 +1129,7 @@ func (h *PetHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetReadView(e), w)
 }
 
 // Read fetches the ent.PlayGroup identified by a given url-parameter from the

--- a/internal/pets/ent/http/relations.go
+++ b/internal/pets/ent/http/relations.go
@@ -10,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	badge "github.com/masseelch/elk/internal/pets/ent/badge"
-	pet "github.com/masseelch/elk/internal/pets/ent/pet"
-	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
-	toy "github.com/masseelch/elk/internal/pets/ent/toy"
+	"github.com/masseelch/elk/internal/pets/ent/badge"
+	"github.com/masseelch/elk/internal/pets/ent/pet"
+	"github.com/masseelch/elk/internal/pets/ent/playgroup"
+	"github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 
@@ -1095,7 +1095,7 @@ func (h BadgeHandler) Wearer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetReadView(e), w)
 }
 
 // Badge fetches the ent.badge attached to the ent.Pet
@@ -2209,7 +2209,7 @@ func (h PetHandler) Protege(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetReadView(e), w)
 }
 
 // Mentor fetches the ent.mentor attached to the ent.Pet
@@ -3289,7 +3289,7 @@ func (h PetHandler) Mentor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetReadView(e), w)
 }
 
 // Spouse fetches the ent.spouse attached to the ent.Pet
@@ -4369,7 +4369,7 @@ func (h PetHandler) Spouse(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetReadView(e), w)
 }
 
 // Toys fetches the ent.toys attached to the ent.Pet
@@ -5490,7 +5490,7 @@ func (h PetHandler) Parent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetReadView(e), w)
 }
 
 // Children fetches the ent.children attached to the ent.Pet
@@ -6740,5 +6740,5 @@ func (h ToyHandler) Owner(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetReadView(e), w)
 }

--- a/internal/pets/ent/http/relations.go
+++ b/internal/pets/ent/http/relations.go
@@ -10,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	"github.com/masseelch/elk/internal/pets/ent/badge"
-	"github.com/masseelch/elk/internal/pets/ent/pet"
-	"github.com/masseelch/elk/internal/pets/ent/playgroup"
-	"github.com/masseelch/elk/internal/pets/ent/toy"
+	badge "github.com/masseelch/elk/internal/pets/ent/badge"
+	pet "github.com/masseelch/elk/internal/pets/ent/pet"
+	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
+	toy "github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 

--- a/internal/pets/ent/http/relations.go
+++ b/internal/pets/ent/http/relations.go
@@ -1095,7 +1095,7 @@ func (h BadgeHandler) Wearer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Badge fetches the ent.badge attached to the ent.Pet
@@ -1129,7 +1129,7 @@ func (h PetHandler) Badge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("badge rendered", zap.Uint32("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewBadge2492344257View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewBadgeView(e), w)
 }
 
 // Protege fetches the ent.protege attached to the ent.Pet
@@ -2209,7 +2209,7 @@ func (h PetHandler) Protege(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Mentor fetches the ent.mentor attached to the ent.Pet
@@ -3289,7 +3289,7 @@ func (h PetHandler) Mentor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Spouse fetches the ent.spouse attached to the ent.Pet
@@ -4369,7 +4369,7 @@ func (h PetHandler) Spouse(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Toys fetches the ent.toys attached to the ent.Pet
@@ -4410,7 +4410,7 @@ func (h PetHandler) Toys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("toys rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewToy36157710Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewToyViews(es), w)
 }
 
 // Parent fetches the ent.parent attached to the ent.Pet
@@ -5490,7 +5490,7 @@ func (h PetHandler) Parent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Children fetches the ent.children attached to the ent.Pet
@@ -5533,7 +5533,7 @@ func (h PetHandler) Children(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet340207500Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // PlayGroups fetches the ent.play_groups attached to the ent.Pet
@@ -5574,7 +5574,7 @@ func (h PetHandler) PlayGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("play-groups rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPlayGroup3432834655Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPlayGroupViews(es), w)
 }
 
 // Friends fetches the ent.friends attached to the ent.Pet
@@ -5617,7 +5617,7 @@ func (h PetHandler) Friends(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet340207500Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // Participants fetches the ent.participants attached to the ent.PlayGroup
@@ -5660,7 +5660,7 @@ func (h PlayGroupHandler) Participants(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet340207500Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // Owner fetches the ent.owner attached to the ent.Toy
@@ -6740,5 +6740,5 @@ func (h ToyHandler) Owner(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet3217017920View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }

--- a/internal/pets/ent/http/request.go
+++ b/internal/pets/ent/http/request.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/masseelch/elk/internal/pets/ent/badge"
-	"github.com/masseelch/elk/internal/pets/ent/pet"
-	"github.com/masseelch/elk/internal/pets/ent/playgroup"
-	"github.com/masseelch/elk/internal/pets/ent/toy"
+	badge "github.com/masseelch/elk/internal/pets/ent/badge"
+	pet "github.com/masseelch/elk/internal/pets/ent/pet"
+	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
+	toy "github.com/masseelch/elk/internal/pets/ent/toy"
 )
 
 // Payload of a ent.Badge create request.

--- a/internal/pets/ent/http/request.go
+++ b/internal/pets/ent/http/request.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	badge "github.com/masseelch/elk/internal/pets/ent/badge"
-	pet "github.com/masseelch/elk/internal/pets/ent/pet"
-	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
-	toy "github.com/masseelch/elk/internal/pets/ent/toy"
+	"github.com/masseelch/elk/internal/pets/ent/badge"
+	"github.com/masseelch/elk/internal/pets/ent/pet"
+	"github.com/masseelch/elk/internal/pets/ent/playgroup"
+	"github.com/masseelch/elk/internal/pets/ent/toy"
 )
 
 // Payload of a ent.Badge create request.

--- a/internal/pets/ent/http/response.go
+++ b/internal/pets/ent/http/response.go
@@ -10,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	"github.com/masseelch/elk/internal/pets/ent/badge"
-	"github.com/masseelch/elk/internal/pets/ent/pet"
-	"github.com/masseelch/elk/internal/pets/ent/playgroup"
-	"github.com/masseelch/elk/internal/pets/ent/toy"
+	badge "github.com/masseelch/elk/internal/pets/ent/badge"
+	pet "github.com/masseelch/elk/internal/pets/ent/pet"
+	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
+	toy "github.com/masseelch/elk/internal/pets/ent/toy"
 )
 
 // Basic HTTP Error Response

--- a/internal/pets/ent/http/response.go
+++ b/internal/pets/ent/http/response.go
@@ -10,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	badge "github.com/masseelch/elk/internal/pets/ent/badge"
-	pet "github.com/masseelch/elk/internal/pets/ent/pet"
-	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
-	toy "github.com/masseelch/elk/internal/pets/ent/toy"
+	"github.com/masseelch/elk/internal/pets/ent/badge"
+	"github.com/masseelch/elk/internal/pets/ent/pet"
+	"github.com/masseelch/elk/internal/pets/ent/playgroup"
+	"github.com/masseelch/elk/internal/pets/ent/toy"
 )
 
 // Basic HTTP Error Response
@@ -85,9 +85,6 @@ func Unauthorized(w http.ResponseWriter, msg interface{}) (int, error) {
 type (
 	// BadgeView represents the data serialized for the following serialization group combinations:
 	// []
-	// [pet:list pet:read]
-	// [pet:read]
-	// [pet:list]
 	BadgeView struct {
 		ID       uint32         `json:"id,omitempty"`
 		Color    badge.Color    `json:"color,omitempty"`
@@ -119,11 +116,262 @@ func NewBadgeViews(es []*ent.Badge) BadgeViews {
 }
 
 type (
+	// BadgeWithPetListAndPetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:list pet:read]
+	BadgeWithPetListAndPetReadView struct {
+		ID       uint32         `json:"id,omitempty"`
+		Color    badge.Color    `json:"color,omitempty"`
+		Material badge.Material `json:"material,omitempty"`
+	}
+	BadgeWithPetListAndPetReadViews []*BadgeWithPetListAndPetReadView
+)
+
+func NewBadgeWithPetListAndPetReadView(e *ent.Badge) *BadgeWithPetListAndPetReadView {
+	if e == nil {
+		return nil
+	}
+	return &BadgeWithPetListAndPetReadView{
+		ID:       e.ID,
+		Color:    e.Color,
+		Material: e.Material,
+	}
+}
+
+func NewBadgeWithPetListAndPetReadViews(es []*ent.Badge) BadgeWithPetListAndPetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(BadgeWithPetListAndPetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewBadgeWithPetListAndPetReadView(e)
+	}
+	return r
+}
+
+type (
+	// BadgeWithPetListView represents the data serialized for the following serialization group combinations:
+	// [pet:list]
+	BadgeWithPetListView struct {
+		ID       uint32         `json:"id,omitempty"`
+		Color    badge.Color    `json:"color,omitempty"`
+		Material badge.Material `json:"material,omitempty"`
+	}
+	BadgeWithPetListViews []*BadgeWithPetListView
+)
+
+func NewBadgeWithPetListView(e *ent.Badge) *BadgeWithPetListView {
+	if e == nil {
+		return nil
+	}
+	return &BadgeWithPetListView{
+		ID:       e.ID,
+		Color:    e.Color,
+		Material: e.Material,
+	}
+}
+
+func NewBadgeWithPetListViews(es []*ent.Badge) BadgeWithPetListViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(BadgeWithPetListViews, len(es))
+	for i, e := range es {
+		r[i] = NewBadgeWithPetListView(e)
+	}
+	return r
+}
+
+type (
+	// BadgeWithPetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:read]
+	BadgeWithPetReadView struct {
+		ID       uint32         `json:"id,omitempty"`
+		Color    badge.Color    `json:"color,omitempty"`
+		Material badge.Material `json:"material,omitempty"`
+	}
+	BadgeWithPetReadViews []*BadgeWithPetReadView
+)
+
+func NewBadgeWithPetReadView(e *ent.Badge) *BadgeWithPetReadView {
+	if e == nil {
+		return nil
+	}
+	return &BadgeWithPetReadView{
+		ID:       e.ID,
+		Color:    e.Color,
+		Material: e.Material,
+	}
+}
+
+func NewBadgeWithPetReadViews(es []*ent.Badge) BadgeWithPetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(BadgeWithPetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewBadgeWithPetReadView(e)
+	}
+	return r
+}
+
+type (
+	// PetListAndPetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:list pet:read]
+	PetListAndPetReadView struct {
+		ID         int                                 `json:"id,omitempty"`
+		Height     int                                 `json:"height,omitempty"`
+		Weight     float64                             `json:"weight,omitempty"`
+		Castrated  bool                                `json:"castrated,omitempty"`
+		Name       string                              `json:"name,omitempty"`
+		Birthday   time.Time                           `json:"birthday,omitempty"`
+		Nicknames  []string                            `json:"nicknames,omitempty"`
+		Sex        pet.Sex                             `json:"sex,omitempty"`
+		Chip       uuid.UUID                           `json:"chip,omitempty"`
+		Badge      *BadgeWithPetListAndPetReadView     `json:"badge,omitempty"`
+		Protege    *PetListAndPetReadView              `json:"protege,omitempty"`
+		Spouse     *PetListAndPetReadView              `json:"spouse,omitempty"`
+		Toys       ToyWithPetListAndPetReadViews       `json:"toys,omitempty"`
+		Parent     *PetListAndPetReadView              `json:"parent,omitempty"`
+		PlayGroups PlayGroupWithPetListAndPetReadViews `json:"play_groups,omitempty"`
+		Friends    PetListAndPetReadViews              `json:"friends,omitempty"`
+	}
+	PetListAndPetReadViews []*PetListAndPetReadView
+)
+
+func NewPetListAndPetReadView(e *ent.Pet) *PetListAndPetReadView {
+	if e == nil {
+		return nil
+	}
+	return &PetListAndPetReadView{
+		ID:         e.ID,
+		Height:     e.Height,
+		Weight:     e.Weight,
+		Castrated:  e.Castrated,
+		Name:       e.Name,
+		Birthday:   e.Birthday,
+		Nicknames:  e.Nicknames,
+		Sex:        e.Sex,
+		Chip:       e.Chip,
+		Badge:      NewBadgeWithPetListAndPetReadView(e.Edges.Badge),
+		Protege:    NewPetListAndPetReadView(e.Edges.Protege),
+		Spouse:     NewPetListAndPetReadView(e.Edges.Spouse),
+		Toys:       NewToyWithPetListAndPetReadViews(e.Edges.Toys),
+		Parent:     NewPetListAndPetReadView(e.Edges.Parent),
+		PlayGroups: NewPlayGroupWithPetListAndPetReadViews(e.Edges.PlayGroups),
+		Friends:    NewPetListAndPetReadViews(e.Edges.Friends),
+	}
+}
+
+func NewPetListAndPetReadViews(es []*ent.Pet) PetListAndPetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PetListAndPetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewPetListAndPetReadView(e)
+	}
+	return r
+}
+
+type (
+	// PetListView represents the data serialized for the following serialization group combinations:
+	// [pet:list]
+	PetListView struct {
+		ID    int                   `json:"id,omitempty"`
+		Name  string                `json:"name,omitempty"`
+		Sex   pet.Sex               `json:"sex,omitempty"`
+		Chip  uuid.UUID             `json:"chip,omitempty"`
+		Badge *BadgeWithPetListView `json:"badge,omitempty"`
+	}
+	PetListViews []*PetListView
+)
+
+func NewPetListView(e *ent.Pet) *PetListView {
+	if e == nil {
+		return nil
+	}
+	return &PetListView{
+		ID:    e.ID,
+		Name:  e.Name,
+		Sex:   e.Sex,
+		Chip:  e.Chip,
+		Badge: NewBadgeWithPetListView(e.Edges.Badge),
+	}
+}
+
+func NewPetListViews(es []*ent.Pet) PetListViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PetListViews, len(es))
+	for i, e := range es {
+		r[i] = NewPetListView(e)
+	}
+	return r
+}
+
+type (
+	// PetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:read]
+	PetReadView struct {
+		ID         int                       `json:"id,omitempty"`
+		Height     int                       `json:"height,omitempty"`
+		Weight     float64                   `json:"weight,omitempty"`
+		Castrated  bool                      `json:"castrated,omitempty"`
+		Name       string                    `json:"name,omitempty"`
+		Birthday   time.Time                 `json:"birthday,omitempty"`
+		Nicknames  []string                  `json:"nicknames,omitempty"`
+		Sex        pet.Sex                   `json:"sex,omitempty"`
+		Chip       uuid.UUID                 `json:"chip,omitempty"`
+		Badge      *BadgeWithPetReadView     `json:"badge,omitempty"`
+		Protege    *PetReadView              `json:"protege,omitempty"`
+		Spouse     *PetReadView              `json:"spouse,omitempty"`
+		Toys       ToyWithPetReadViews       `json:"toys,omitempty"`
+		Parent     *PetReadView              `json:"parent,omitempty"`
+		PlayGroups PlayGroupWithPetReadViews `json:"play_groups,omitempty"`
+		Friends    PetReadViews              `json:"friends,omitempty"`
+	}
+	PetReadViews []*PetReadView
+)
+
+func NewPetReadView(e *ent.Pet) *PetReadView {
+	if e == nil {
+		return nil
+	}
+	return &PetReadView{
+		ID:         e.ID,
+		Height:     e.Height,
+		Weight:     e.Weight,
+		Castrated:  e.Castrated,
+		Name:       e.Name,
+		Birthday:   e.Birthday,
+		Nicknames:  e.Nicknames,
+		Sex:        e.Sex,
+		Chip:       e.Chip,
+		Badge:      NewBadgeWithPetReadView(e.Edges.Badge),
+		Protege:    NewPetReadView(e.Edges.Protege),
+		Spouse:     NewPetReadView(e.Edges.Spouse),
+		Toys:       NewToyWithPetReadViews(e.Edges.Toys),
+		Parent:     NewPetReadView(e.Edges.Parent),
+		PlayGroups: NewPlayGroupWithPetReadViews(e.Edges.PlayGroups),
+		Friends:    NewPetReadViews(e.Edges.Friends),
+	}
+}
+
+func NewPetReadViews(es []*ent.Pet) PetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewPetReadView(e)
+	}
+	return r
+}
+
+type (
 	// PetView represents the data serialized for the following serialization group combinations:
 	// []
-	// [pet:list pet:read]
-	// [pet:read]
-	// [pet:list]
 	PetView struct {
 		ID        int       `json:"id,omitempty"`
 		Height    int       `json:"height,omitempty"`
@@ -169,9 +417,6 @@ func NewPetViews(es []*ent.Pet) PetViews {
 type (
 	// PlayGroupView represents the data serialized for the following serialization group combinations:
 	// []
-	// [pet:list pet:read]
-	// [pet:read]
-	// [pet:list]
 	PlayGroupView struct {
 		ID          int               `json:"id,omitempty"`
 		Title       string            `json:"title,omitempty"`
@@ -205,11 +450,113 @@ func NewPlayGroupViews(es []*ent.PlayGroup) PlayGroupViews {
 }
 
 type (
+	// PlayGroupWithPetListAndPetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:list pet:read]
+	PlayGroupWithPetListAndPetReadView struct {
+		ID          int               `json:"id,omitempty"`
+		Title       string            `json:"title,omitempty"`
+		Description string            `json:"description,omitempty"`
+		Weekday     playgroup.Weekday `json:"weekday,omitempty"`
+	}
+	PlayGroupWithPetListAndPetReadViews []*PlayGroupWithPetListAndPetReadView
+)
+
+func NewPlayGroupWithPetListAndPetReadView(e *ent.PlayGroup) *PlayGroupWithPetListAndPetReadView {
+	if e == nil {
+		return nil
+	}
+	return &PlayGroupWithPetListAndPetReadView{
+		ID:          e.ID,
+		Title:       e.Title,
+		Description: e.Description,
+		Weekday:     e.Weekday,
+	}
+}
+
+func NewPlayGroupWithPetListAndPetReadViews(es []*ent.PlayGroup) PlayGroupWithPetListAndPetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PlayGroupWithPetListAndPetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewPlayGroupWithPetListAndPetReadView(e)
+	}
+	return r
+}
+
+type (
+	// PlayGroupWithPetListView represents the data serialized for the following serialization group combinations:
+	// [pet:list]
+	PlayGroupWithPetListView struct {
+		ID          int               `json:"id,omitempty"`
+		Title       string            `json:"title,omitempty"`
+		Description string            `json:"description,omitempty"`
+		Weekday     playgroup.Weekday `json:"weekday,omitempty"`
+	}
+	PlayGroupWithPetListViews []*PlayGroupWithPetListView
+)
+
+func NewPlayGroupWithPetListView(e *ent.PlayGroup) *PlayGroupWithPetListView {
+	if e == nil {
+		return nil
+	}
+	return &PlayGroupWithPetListView{
+		ID:          e.ID,
+		Title:       e.Title,
+		Description: e.Description,
+		Weekday:     e.Weekday,
+	}
+}
+
+func NewPlayGroupWithPetListViews(es []*ent.PlayGroup) PlayGroupWithPetListViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PlayGroupWithPetListViews, len(es))
+	for i, e := range es {
+		r[i] = NewPlayGroupWithPetListView(e)
+	}
+	return r
+}
+
+type (
+	// PlayGroupWithPetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:read]
+	PlayGroupWithPetReadView struct {
+		ID          int               `json:"id,omitempty"`
+		Title       string            `json:"title,omitempty"`
+		Description string            `json:"description,omitempty"`
+		Weekday     playgroup.Weekday `json:"weekday,omitempty"`
+	}
+	PlayGroupWithPetReadViews []*PlayGroupWithPetReadView
+)
+
+func NewPlayGroupWithPetReadView(e *ent.PlayGroup) *PlayGroupWithPetReadView {
+	if e == nil {
+		return nil
+	}
+	return &PlayGroupWithPetReadView{
+		ID:          e.ID,
+		Title:       e.Title,
+		Description: e.Description,
+		Weekday:     e.Weekday,
+	}
+}
+
+func NewPlayGroupWithPetReadViews(es []*ent.PlayGroup) PlayGroupWithPetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PlayGroupWithPetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewPlayGroupWithPetReadView(e)
+	}
+	return r
+}
+
+type (
 	// ToyView represents the data serialized for the following serialization group combinations:
 	// []
-	// [pet:list pet:read]
-	// [pet:read]
-	// [pet:list]
 	ToyView struct {
 		ID       uuid.UUID    `json:"id,omitempty"`
 		Color    toy.Color    `json:"color,omitempty"`
@@ -238,6 +585,111 @@ func NewToyViews(es []*ent.Toy) ToyViews {
 	r := make(ToyViews, len(es))
 	for i, e := range es {
 		r[i] = NewToyView(e)
+	}
+	return r
+}
+
+type (
+	// ToyWithPetListAndPetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:list pet:read]
+	ToyWithPetListAndPetReadView struct {
+		ID       uuid.UUID    `json:"id,omitempty"`
+		Color    toy.Color    `json:"color,omitempty"`
+		Material toy.Material `json:"material,omitempty"`
+		Title    string       `json:"title,omitempty"`
+	}
+	ToyWithPetListAndPetReadViews []*ToyWithPetListAndPetReadView
+)
+
+func NewToyWithPetListAndPetReadView(e *ent.Toy) *ToyWithPetListAndPetReadView {
+	if e == nil {
+		return nil
+	}
+	return &ToyWithPetListAndPetReadView{
+		ID:       e.ID,
+		Color:    e.Color,
+		Material: e.Material,
+		Title:    e.Title,
+	}
+}
+
+func NewToyWithPetListAndPetReadViews(es []*ent.Toy) ToyWithPetListAndPetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(ToyWithPetListAndPetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewToyWithPetListAndPetReadView(e)
+	}
+	return r
+}
+
+type (
+	// ToyWithPetListView represents the data serialized for the following serialization group combinations:
+	// [pet:list]
+	ToyWithPetListView struct {
+		ID       uuid.UUID    `json:"id,omitempty"`
+		Color    toy.Color    `json:"color,omitempty"`
+		Material toy.Material `json:"material,omitempty"`
+		Title    string       `json:"title,omitempty"`
+	}
+	ToyWithPetListViews []*ToyWithPetListView
+)
+
+func NewToyWithPetListView(e *ent.Toy) *ToyWithPetListView {
+	if e == nil {
+		return nil
+	}
+	return &ToyWithPetListView{
+		ID:       e.ID,
+		Color:    e.Color,
+		Material: e.Material,
+		Title:    e.Title,
+	}
+}
+
+func NewToyWithPetListViews(es []*ent.Toy) ToyWithPetListViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(ToyWithPetListViews, len(es))
+	for i, e := range es {
+		r[i] = NewToyWithPetListView(e)
+	}
+	return r
+}
+
+type (
+	// ToyWithPetReadView represents the data serialized for the following serialization group combinations:
+	// [pet:read]
+	ToyWithPetReadView struct {
+		ID       uuid.UUID    `json:"id,omitempty"`
+		Color    toy.Color    `json:"color,omitempty"`
+		Material toy.Material `json:"material,omitempty"`
+		Title    string       `json:"title,omitempty"`
+	}
+	ToyWithPetReadViews []*ToyWithPetReadView
+)
+
+func NewToyWithPetReadView(e *ent.Toy) *ToyWithPetReadView {
+	if e == nil {
+		return nil
+	}
+	return &ToyWithPetReadView{
+		ID:       e.ID,
+		Color:    e.Color,
+		Material: e.Material,
+		Title:    e.Title,
+	}
+}
+
+func NewToyWithPetReadViews(es []*ent.Toy) ToyWithPetReadViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(ToyWithPetReadViews, len(es))
+	for i, e := range es {
+		r[i] = NewToyWithPetReadView(e)
 	}
 	return r
 }

--- a/internal/pets/ent/http/response.go
+++ b/internal/pets/ent/http/response.go
@@ -83,105 +83,48 @@ func Unauthorized(w http.ResponseWriter, msg interface{}) (int, error) {
 }
 
 type (
-	// Badge2492344257View represents the data serialized for the following serialization group combinations:
+	// BadgeView represents the data serialized for the following serialization group combinations:
 	// []
 	// [pet:list pet:read]
 	// [pet:read]
 	// [pet:list]
-	Badge2492344257View struct {
+	BadgeView struct {
 		ID       uint32         `json:"id,omitempty"`
 		Color    badge.Color    `json:"color,omitempty"`
 		Material badge.Material `json:"material,omitempty"`
 	}
-	Badge2492344257Views []*Badge2492344257View
+	BadgeViews []*BadgeView
 )
 
-func NewBadge2492344257View(e *ent.Badge) *Badge2492344257View {
+func NewBadgeView(e *ent.Badge) *BadgeView {
 	if e == nil {
 		return nil
 	}
-	return &Badge2492344257View{
+	return &BadgeView{
 		ID:       e.ID,
 		Color:    e.Color,
 		Material: e.Material,
 	}
 }
 
-func NewBadge2492344257Views(es []*ent.Badge) Badge2492344257Views {
+func NewBadgeViews(es []*ent.Badge) BadgeViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Badge2492344257Views, len(es))
+	r := make(BadgeViews, len(es))
 	for i, e := range es {
-		r[i] = NewBadge2492344257View(e)
+		r[i] = NewBadgeView(e)
 	}
 	return r
 }
 
 type (
-	// Pet3217017920View represents the data serialized for the following serialization group combinations:
+	// PetView represents the data serialized for the following serialization group combinations:
+	// []
 	// [pet:list pet:read]
 	// [pet:read]
-	Pet3217017920View struct {
-		ID         int                      `json:"id,omitempty"`
-		Height     int                      `json:"height,omitempty"`
-		Weight     float64                  `json:"weight,omitempty"`
-		Castrated  bool                     `json:"castrated,omitempty"`
-		Name       string                   `json:"name,omitempty"`
-		Birthday   time.Time                `json:"birthday,omitempty"`
-		Nicknames  []string                 `json:"nicknames,omitempty"`
-		Sex        pet.Sex                  `json:"sex,omitempty"`
-		Chip       uuid.UUID                `json:"chip,omitempty"`
-		Badge      *Badge2492344257View     `json:"badge,omitempty"`
-		Protege    *Pet340207500View        `json:"protege,omitempty"`
-		Spouse     *Pet340207500View        `json:"spouse,omitempty"`
-		Toys       Toy36157710Views         `json:"toys,omitempty"`
-		Parent     *Pet340207500View        `json:"parent,omitempty"`
-		PlayGroups PlayGroup3432834655Views `json:"play_groups,omitempty"`
-		Friends    Pet340207500Views        `json:"friends,omitempty"`
-	}
-	Pet3217017920Views []*Pet3217017920View
-)
-
-func NewPet3217017920View(e *ent.Pet) *Pet3217017920View {
-	if e == nil {
-		return nil
-	}
-	return &Pet3217017920View{
-		ID:         e.ID,
-		Height:     e.Height,
-		Weight:     e.Weight,
-		Castrated:  e.Castrated,
-		Name:       e.Name,
-		Birthday:   e.Birthday,
-		Nicknames:  e.Nicknames,
-		Sex:        e.Sex,
-		Chip:       e.Chip,
-		Badge:      NewBadge2492344257View(e.Edges.Badge),
-		Protege:    NewPet340207500View(e.Edges.Protege),
-		Spouse:     NewPet340207500View(e.Edges.Spouse),
-		Toys:       NewToy36157710Views(e.Edges.Toys),
-		Parent:     NewPet340207500View(e.Edges.Parent),
-		PlayGroups: NewPlayGroup3432834655Views(e.Edges.PlayGroups),
-		Friends:    NewPet340207500Views(e.Edges.Friends),
-	}
-}
-
-func NewPet3217017920Views(es []*ent.Pet) Pet3217017920Views {
-	if len(es) == 0 {
-		return nil
-	}
-	r := make(Pet3217017920Views, len(es))
-	for i, e := range es {
-		r[i] = NewPet3217017920View(e)
-	}
-	return r
-}
-
-type (
-	// Pet340207500View represents the data serialized for the following serialization group combinations:
-	// []
-	Pet340207500View struct {
+	// [pet:list]
+	PetView struct {
 		ID        int       `json:"id,omitempty"`
 		Height    int       `json:"height,omitempty"`
 		Weight    float64   `json:"weight,omitempty"`
@@ -192,14 +135,14 @@ type (
 		Sex       pet.Sex   `json:"sex,omitempty"`
 		Chip      uuid.UUID `json:"chip,omitempty"`
 	}
-	Pet340207500Views []*Pet340207500View
+	PetViews []*PetView
 )
 
-func NewPet340207500View(e *ent.Pet) *Pet340207500View {
+func NewPetView(e *ent.Pet) *PetView {
 	if e == nil {
 		return nil
 	}
-	return &Pet340207500View{
+	return &PetView{
 		ID:        e.ID,
 		Height:    e.Height,
 		Weight:    e.Weight,
@@ -212,74 +155,37 @@ func NewPet340207500View(e *ent.Pet) *Pet340207500View {
 	}
 }
 
-func NewPet340207500Views(es []*ent.Pet) Pet340207500Views {
+func NewPetViews(es []*ent.Pet) PetViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Pet340207500Views, len(es))
+	r := make(PetViews, len(es))
 	for i, e := range es {
-		r[i] = NewPet340207500View(e)
+		r[i] = NewPetView(e)
 	}
 	return r
 }
 
 type (
-	// Pet45794832View represents the data serialized for the following serialization group combinations:
-	// [pet:list]
-	Pet45794832View struct {
-		ID    int                  `json:"id,omitempty"`
-		Name  string               `json:"name,omitempty"`
-		Sex   pet.Sex              `json:"sex,omitempty"`
-		Chip  uuid.UUID            `json:"chip,omitempty"`
-		Badge *Badge2492344257View `json:"badge,omitempty"`
-	}
-	Pet45794832Views []*Pet45794832View
-)
-
-func NewPet45794832View(e *ent.Pet) *Pet45794832View {
-	if e == nil {
-		return nil
-	}
-	return &Pet45794832View{
-		ID:    e.ID,
-		Name:  e.Name,
-		Sex:   e.Sex,
-		Chip:  e.Chip,
-		Badge: NewBadge2492344257View(e.Edges.Badge),
-	}
-}
-
-func NewPet45794832Views(es []*ent.Pet) Pet45794832Views {
-	if len(es) == 0 {
-		return nil
-	}
-	r := make(Pet45794832Views, len(es))
-	for i, e := range es {
-		r[i] = NewPet45794832View(e)
-	}
-	return r
-}
-
-type (
-	// PlayGroup3432834655View represents the data serialized for the following serialization group combinations:
+	// PlayGroupView represents the data serialized for the following serialization group combinations:
 	// []
 	// [pet:list pet:read]
 	// [pet:read]
 	// [pet:list]
-	PlayGroup3432834655View struct {
+	PlayGroupView struct {
 		ID          int               `json:"id,omitempty"`
 		Title       string            `json:"title,omitempty"`
 		Description string            `json:"description,omitempty"`
 		Weekday     playgroup.Weekday `json:"weekday,omitempty"`
 	}
-	PlayGroup3432834655Views []*PlayGroup3432834655View
+	PlayGroupViews []*PlayGroupView
 )
 
-func NewPlayGroup3432834655View(e *ent.PlayGroup) *PlayGroup3432834655View {
+func NewPlayGroupView(e *ent.PlayGroup) *PlayGroupView {
 	if e == nil {
 		return nil
 	}
-	return &PlayGroup3432834655View{
+	return &PlayGroupView{
 		ID:          e.ID,
 		Title:       e.Title,
 		Description: e.Description,
@@ -287,37 +193,37 @@ func NewPlayGroup3432834655View(e *ent.PlayGroup) *PlayGroup3432834655View {
 	}
 }
 
-func NewPlayGroup3432834655Views(es []*ent.PlayGroup) PlayGroup3432834655Views {
+func NewPlayGroupViews(es []*ent.PlayGroup) PlayGroupViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(PlayGroup3432834655Views, len(es))
+	r := make(PlayGroupViews, len(es))
 	for i, e := range es {
-		r[i] = NewPlayGroup3432834655View(e)
+		r[i] = NewPlayGroupView(e)
 	}
 	return r
 }
 
 type (
-	// Toy36157710View represents the data serialized for the following serialization group combinations:
+	// ToyView represents the data serialized for the following serialization group combinations:
 	// []
 	// [pet:list pet:read]
 	// [pet:read]
 	// [pet:list]
-	Toy36157710View struct {
+	ToyView struct {
 		ID       uuid.UUID    `json:"id,omitempty"`
 		Color    toy.Color    `json:"color,omitempty"`
 		Material toy.Material `json:"material,omitempty"`
 		Title    string       `json:"title,omitempty"`
 	}
-	Toy36157710Views []*Toy36157710View
+	ToyViews []*ToyView
 )
 
-func NewToy36157710View(e *ent.Toy) *Toy36157710View {
+func NewToyView(e *ent.Toy) *ToyView {
 	if e == nil {
 		return nil
 	}
-	return &Toy36157710View{
+	return &ToyView{
 		ID:       e.ID,
 		Color:    e.Color,
 		Material: e.Material,
@@ -325,13 +231,13 @@ func NewToy36157710View(e *ent.Toy) *Toy36157710View {
 	}
 }
 
-func NewToy36157710Views(es []*ent.Toy) Toy36157710Views {
+func NewToyViews(es []*ent.Toy) ToyViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Toy36157710Views, len(es))
+	r := make(ToyViews, len(es))
 	for i, e := range es {
-		r[i] = NewToy36157710View(e)
+		r[i] = NewToyView(e)
 	}
 	return r
 }

--- a/internal/pets/ent/http/update.go
+++ b/internal/pets/ent/http/update.go
@@ -86,7 +86,7 @@ func (h BadgeHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("badge rendered", zap.Uint32("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewBadge2492344257View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewBadgeView(e), w)
 }
 
 // Update updates a given ent.Pet and saves the changes to the database.
@@ -227,7 +227,7 @@ func (h PetHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet340207500View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Update updates a given ent.PlayGroup and saves the changes to the database.
@@ -299,7 +299,7 @@ func (h PlayGroupHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("play-group rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPlayGroup3432834655View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPlayGroupView(e), w)
 }
 
 // Update updates a given ent.Toy and saves the changes to the database.
@@ -372,5 +372,5 @@ func (h ToyHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("toy rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewToy36157710View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewToyView(e), w)
 }

--- a/internal/pets/ent/http/update.go
+++ b/internal/pets/ent/http/update.go
@@ -11,10 +11,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	"github.com/masseelch/elk/internal/pets/ent/badge"
-	"github.com/masseelch/elk/internal/pets/ent/pet"
-	"github.com/masseelch/elk/internal/pets/ent/playgroup"
-	"github.com/masseelch/elk/internal/pets/ent/toy"
+	badge "github.com/masseelch/elk/internal/pets/ent/badge"
+	pet "github.com/masseelch/elk/internal/pets/ent/pet"
+	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
+	toy "github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 

--- a/internal/pets/ent/http/update.go
+++ b/internal/pets/ent/http/update.go
@@ -11,10 +11,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mailru/easyjson"
 	"github.com/masseelch/elk/internal/pets/ent"
-	badge "github.com/masseelch/elk/internal/pets/ent/badge"
-	pet "github.com/masseelch/elk/internal/pets/ent/pet"
-	playgroup "github.com/masseelch/elk/internal/pets/ent/playgroup"
-	toy "github.com/masseelch/elk/internal/pets/ent/toy"
+	"github.com/masseelch/elk/internal/pets/ent/badge"
+	"github.com/masseelch/elk/internal/pets/ent/pet"
+	"github.com/masseelch/elk/internal/pets/ent/playgroup"
+	"github.com/masseelch/elk/internal/pets/ent/toy"
 	"go.uber.org/zap"
 )
 

--- a/internal/simple/ent/http/create.go
+++ b/internal/simple/ent/http/create.go
@@ -41,27 +41,29 @@ func (h CategoryHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Category.Query().Where(category.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Uint64("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Uint64("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Uint64("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Uint64("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read category", zap.Error(err), zap.Uint64("id", e.ID))
+			l.Error("could not read category", zap.Error(err), zap.Uint64("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("category rendered", zap.Uint64("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(e), w)
+	l.Info("category rendered", zap.Uint64("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(ret), w)
 }
 
 // Create creates a new ent.Collar and stores it in the database.
@@ -91,27 +93,29 @@ func (h CollarHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Collar.Query().Where(collar.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.Int("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.Int("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read collar", zap.Error(err), zap.Int("id", e.ID))
+			l.Error("could not read collar", zap.Error(err), zap.Int("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("collar rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
+	l.Info("collar rendered", zap.Int("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(ret), w)
 }
 
 // Create creates a new ent.Owner and stores it in the database.
@@ -144,27 +148,29 @@ func (h OwnerHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Owner.Query().Where(owner.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.String("id", e.ID.String()))
+			l.Info(msg, zap.Error(err), zap.String("id", id.String()))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.String("id", e.ID.String()))
+			l.Error(msg, zap.Error(err), zap.String("id", id.String()))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read owner", zap.Error(err), zap.String("id", e.ID.String()))
+			l.Error("could not read owner", zap.Error(err), zap.String("id", id.String()))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("owner rendered", zap.String("id", e.ID.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
+	l.Info("owner rendered", zap.String("id", id.String()))
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(ret), w)
 }
 
 // Create creates a new ent.Pet and stores it in the database.
@@ -206,25 +212,27 @@ func (h PetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Store id of fresh entity to log errors for the reload.
+	id := e.ID
 	// Reload entry.
 	q := h.client.Pet.Query().Where(pet.ID(e.ID))
-	e, err = q.Only(r.Context())
+	ret, err := q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.String("id", e.ID))
+			l.Info(msg, zap.Error(err), zap.String("id", id))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.String("id", e.ID))
+			l.Error(msg, zap.Error(err), zap.String("id", id))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read pet", zap.Error(err), zap.String("id", e.ID))
+			l.Error("could not read pet", zap.Error(err), zap.String("id", id))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("pet rendered", zap.String("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	l.Info("pet rendered", zap.String("id", id))
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(ret), w)
 }

--- a/internal/simple/ent/http/create.go
+++ b/internal/simple/ent/http/create.go
@@ -41,29 +41,27 @@ func (h CategoryHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Category.Query().Where(category.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Uint64("id", id))
+			l.Info(msg, zap.Error(err), zap.Uint64("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Uint64("id", id))
+			l.Error(msg, zap.Error(err), zap.Uint64("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read category", zap.Error(err), zap.Uint64("id", id))
+			l.Error("could not read category", zap.Error(err), zap.Uint64("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("category rendered", zap.Uint64("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247View(ret), w)
+	l.Info("category rendered", zap.Uint64("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(e), w)
 }
 
 // Create creates a new ent.Collar and stores it in the database.
@@ -93,29 +91,27 @@ func (h CollarHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Collar.Query().Where(collar.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.Int("id", id))
+			l.Info(msg, zap.Error(err), zap.Int("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.Int("id", id))
+			l.Error(msg, zap.Error(err), zap.Int("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read collar", zap.Error(err), zap.Int("id", id))
+			l.Error("could not read collar", zap.Error(err), zap.Int("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("collar rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(ret), w)
+	l.Info("collar rendered", zap.Int("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
 }
 
 // Create creates a new ent.Owner and stores it in the database.
@@ -148,29 +144,27 @@ func (h OwnerHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Owner.Query().Where(owner.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.String("id", id.String()))
+			l.Info(msg, zap.Error(err), zap.String("id", e.ID.String()))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.String("id", id.String()))
+			l.Error(msg, zap.Error(err), zap.String("id", e.ID.String()))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read owner", zap.Error(err), zap.String("id", id.String()))
+			l.Error("could not read owner", zap.Error(err), zap.String("id", e.ID.String()))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("owner rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(ret), w)
+	l.Info("owner rendered", zap.String("id", e.ID.String()))
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
 }
 
 // Create creates a new ent.Pet and stores it in the database.
@@ -212,27 +206,25 @@ func (h PetHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// Store id of fresh entity to log errors for the reload.
-	id := e.ID
 	// Reload entry.
 	q := h.client.Pet.Query().Where(pet.ID(e.ID))
-	ret, err := q.Only(r.Context())
+	e, err = q.Only(r.Context())
 	if err != nil {
 		switch {
 		case ent.IsNotFound(err):
 			msg := stripEntError(err)
-			l.Info(msg, zap.Error(err), zap.String("id", id))
+			l.Info(msg, zap.Error(err), zap.String("id", e.ID))
 			NotFound(w, msg)
 		case ent.IsNotSingular(err):
 			msg := stripEntError(err)
-			l.Error(msg, zap.Error(err), zap.String("id", id))
+			l.Error(msg, zap.Error(err), zap.String("id", e.ID))
 			BadRequest(w, msg)
 		default:
-			l.Error("could not read pet", zap.Error(err), zap.String("id", id))
+			l.Error("could not read pet", zap.Error(err), zap.String("id", e.ID))
 			InternalServerError(w, nil)
 		}
 		return
 	}
-	l.Info("pet rendered", zap.String("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019View(ret), w)
+	l.Info("pet rendered", zap.String("id", e.ID))
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }

--- a/internal/simple/ent/http/easyjson.go
+++ b/internal/simple/ent/http/easyjson.go
@@ -19,417 +19,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(in *jlexer.Lexer, out *PetUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "age":
-			if in.IsNull() {
-				in.Skip()
-				out.Age = nil
-			} else {
-				if out.Age == nil {
-					out.Age = new(int)
-				}
-				*out.Age = int(in.Int())
-			}
-		case "collar":
-			if in.IsNull() {
-				in.Skip()
-				out.Collar = nil
-			} else {
-				if out.Collar == nil {
-					out.Collar = new(int)
-				}
-				*out.Collar = int(in.Int())
-			}
-		case "categories":
-			if in.IsNull() {
-				in.Skip()
-				out.Categories = nil
-			} else {
-				in.Delim('[')
-				if out.Categories == nil {
-					if !in.IsDelim(']') {
-						out.Categories = make([]uint64, 0, 8)
-					} else {
-						out.Categories = []uint64{}
-					}
-				} else {
-					out.Categories = (out.Categories)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v1 uint64
-					v1 = uint64(in.Uint64())
-					out.Categories = append(out.Categories, v1)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "owner":
-			if in.IsNull() {
-				in.Skip()
-				out.Owner = nil
-			} else {
-				if out.Owner == nil {
-					out.Owner = new(uuid.UUID)
-				}
-				if data := in.UnsafeBytes(); in.Ok() {
-					in.AddError((*out.Owner).UnmarshalText(data))
-				}
-			}
-		case "friends":
-			if in.IsNull() {
-				in.Skip()
-				out.Friends = nil
-			} else {
-				in.Delim('[')
-				if out.Friends == nil {
-					if !in.IsDelim(']') {
-						out.Friends = make([]string, 0, 4)
-					} else {
-						out.Friends = []string{}
-					}
-				} else {
-					out.Friends = (out.Friends)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v2 string
-					v2 = string(in.String())
-					out.Friends = append(out.Friends, v2)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(out *jwriter.Writer, in PetUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"age\":"
-		out.RawString(prefix)
-		if in.Age == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Age))
-		}
-	}
-	{
-		const prefix string = ",\"collar\":"
-		out.RawString(prefix)
-		if in.Collar == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Collar))
-		}
-	}
-	{
-		const prefix string = ",\"categories\":"
-		out.RawString(prefix)
-		if in.Categories == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v3, v4 := range in.Categories {
-				if v3 > 0 {
-					out.RawByte(',')
-				}
-				out.Uint64(uint64(v4))
-			}
-			out.RawByte(']')
-		}
-	}
-	{
-		const prefix string = ",\"owner\":"
-		out.RawString(prefix)
-		if in.Owner == nil {
-			out.RawString("null")
-		} else {
-			out.RawText((*in.Owner).MarshalText())
-		}
-	}
-	{
-		const prefix string = ",\"friends\":"
-		out.RawString(prefix)
-		if in.Friends == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v5, v6 := range in.Friends {
-				if v5 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v6))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PetUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PetUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(in *jlexer.Lexer, out *PetCreateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "name":
-			if in.IsNull() {
-				in.Skip()
-				out.Name = nil
-			} else {
-				if out.Name == nil {
-					out.Name = new(string)
-				}
-				*out.Name = string(in.String())
-			}
-		case "age":
-			if in.IsNull() {
-				in.Skip()
-				out.Age = nil
-			} else {
-				if out.Age == nil {
-					out.Age = new(int)
-				}
-				*out.Age = int(in.Int())
-			}
-		case "collar":
-			if in.IsNull() {
-				in.Skip()
-				out.Collar = nil
-			} else {
-				if out.Collar == nil {
-					out.Collar = new(int)
-				}
-				*out.Collar = int(in.Int())
-			}
-		case "categories":
-			if in.IsNull() {
-				in.Skip()
-				out.Categories = nil
-			} else {
-				in.Delim('[')
-				if out.Categories == nil {
-					if !in.IsDelim(']') {
-						out.Categories = make([]uint64, 0, 8)
-					} else {
-						out.Categories = []uint64{}
-					}
-				} else {
-					out.Categories = (out.Categories)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v7 uint64
-					v7 = uint64(in.Uint64())
-					out.Categories = append(out.Categories, v7)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "owner":
-			if in.IsNull() {
-				in.Skip()
-				out.Owner = nil
-			} else {
-				if out.Owner == nil {
-					out.Owner = new(uuid.UUID)
-				}
-				if data := in.UnsafeBytes(); in.Ok() {
-					in.AddError((*out.Owner).UnmarshalText(data))
-				}
-			}
-		case "friends":
-			if in.IsNull() {
-				in.Skip()
-				out.Friends = nil
-			} else {
-				in.Delim('[')
-				if out.Friends == nil {
-					if !in.IsDelim(']') {
-						out.Friends = make([]string, 0, 4)
-					} else {
-						out.Friends = []string{}
-					}
-				} else {
-					out.Friends = (out.Friends)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v8 string
-					v8 = string(in.String())
-					out.Friends = append(out.Friends, v8)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(out *jwriter.Writer, in PetCreateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"name\":"
-		out.RawString(prefix[1:])
-		if in.Name == nil {
-			out.RawString("null")
-		} else {
-			out.String(string(*in.Name))
-		}
-	}
-	{
-		const prefix string = ",\"age\":"
-		out.RawString(prefix)
-		if in.Age == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Age))
-		}
-	}
-	{
-		const prefix string = ",\"collar\":"
-		out.RawString(prefix)
-		if in.Collar == nil {
-			out.RawString("null")
-		} else {
-			out.Int(int(*in.Collar))
-		}
-	}
-	{
-		const prefix string = ",\"categories\":"
-		out.RawString(prefix)
-		if in.Categories == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v9, v10 := range in.Categories {
-				if v9 > 0 {
-					out.RawByte(',')
-				}
-				out.Uint64(uint64(v10))
-			}
-			out.RawByte(']')
-		}
-	}
-	{
-		const prefix string = ",\"owner\":"
-		out.RawString(prefix)
-		if in.Owner == nil {
-			out.RawString("null")
-		} else {
-			out.RawText((*in.Owner).MarshalText())
-		}
-	}
-	{
-		const prefix string = ",\"friends\":"
-		out.RawString(prefix)
-		if in.Friends == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-			out.RawString("null")
-		} else {
-			out.RawByte('[')
-			for v11, v12 := range in.Friends {
-				if v11 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v12))
-			}
-			out.RawByte(']')
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PetCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexer.Lexer, out *Pet359800019Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(in *jlexer.Lexer, out *PetViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -438,25 +28,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexe
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Pet359800019Views, 0, 8)
+				*out = make(PetViews, 0, 8)
 			} else {
-				*out = Pet359800019Views{}
+				*out = PetViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v13 *Pet359800019View
+			var v1 *PetView
 			if in.IsNull() {
 				in.Skip()
-				v13 = nil
+				v1 = nil
 			} else {
-				if v13 == nil {
-					v13 = new(Pet359800019View)
+				if v1 == nil {
+					v1 = new(PetView)
 				}
-				(*v13).UnmarshalEasyJSON(in)
+				(*v1).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v13)
+			*out = append(*out, v1)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -465,19 +55,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwriter.Writer, in Pet359800019Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(out *jwriter.Writer, in PetViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v14, v15 := range in {
-			if v14 > 0 {
+		for v2, v3 := range in {
+			if v2 > 0 {
 				out.RawByte(',')
 			}
-			if v15 == nil {
+			if v3 == nil {
 				out.RawString("null")
 			} else {
-				(*v15).MarshalEasyJSON(out)
+				(*v3).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -485,15 +75,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet359800019Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(w, v)
+func (v PetViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet359800019Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(l, v)
+func (v *PetViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexer.Lexer, out *Pet359800019View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(in *jlexer.Lexer, out *PetView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -532,7 +122,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwriter.Writer, in Pet359800019View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(out *jwriter.Writer, in PetView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -566,15 +156,425 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet359800019View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v PetView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexer.Lexer, out *PetUpdateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "age":
+			if in.IsNull() {
+				in.Skip()
+				out.Age = nil
+			} else {
+				if out.Age == nil {
+					out.Age = new(int)
+				}
+				*out.Age = int(in.Int())
+			}
+		case "collar":
+			if in.IsNull() {
+				in.Skip()
+				out.Collar = nil
+			} else {
+				if out.Collar == nil {
+					out.Collar = new(int)
+				}
+				*out.Collar = int(in.Int())
+			}
+		case "categories":
+			if in.IsNull() {
+				in.Skip()
+				out.Categories = nil
+			} else {
+				in.Delim('[')
+				if out.Categories == nil {
+					if !in.IsDelim(']') {
+						out.Categories = make([]uint64, 0, 8)
+					} else {
+						out.Categories = []uint64{}
+					}
+				} else {
+					out.Categories = (out.Categories)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v4 uint64
+					v4 = uint64(in.Uint64())
+					out.Categories = append(out.Categories, v4)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "owner":
+			if in.IsNull() {
+				in.Skip()
+				out.Owner = nil
+			} else {
+				if out.Owner == nil {
+					out.Owner = new(uuid.UUID)
+				}
+				if data := in.UnsafeBytes(); in.Ok() {
+					in.AddError((*out.Owner).UnmarshalText(data))
+				}
+			}
+		case "friends":
+			if in.IsNull() {
+				in.Skip()
+				out.Friends = nil
+			} else {
+				in.Delim('[')
+				if out.Friends == nil {
+					if !in.IsDelim(']') {
+						out.Friends = make([]string, 0, 4)
+					} else {
+						out.Friends = []string{}
+					}
+				} else {
+					out.Friends = (out.Friends)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v5 string
+					v5 = string(in.String())
+					out.Friends = append(out.Friends, v5)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwriter.Writer, in PetUpdateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Name))
+		}
+	}
+	{
+		const prefix string = ",\"age\":"
+		out.RawString(prefix)
+		if in.Age == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Age))
+		}
+	}
+	{
+		const prefix string = ",\"collar\":"
+		out.RawString(prefix)
+		if in.Collar == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Collar))
+		}
+	}
+	{
+		const prefix string = ",\"categories\":"
+		out.RawString(prefix)
+		if in.Categories == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v6, v7 := range in.Categories {
+				if v6 > 0 {
+					out.RawByte(',')
+				}
+				out.Uint64(uint64(v7))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"owner\":"
+		out.RawString(prefix)
+		if in.Owner == nil {
+			out.RawString("null")
+		} else {
+			out.RawText((*in.Owner).MarshalText())
+		}
+	}
+	{
+		const prefix string = ",\"friends\":"
+		out.RawString(prefix)
+		if in.Friends == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v8, v9 := range in.Friends {
+				if v8 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v9))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexer.Lexer, out *PetCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			if in.IsNull() {
+				in.Skip()
+				out.Name = nil
+			} else {
+				if out.Name == nil {
+					out.Name = new(string)
+				}
+				*out.Name = string(in.String())
+			}
+		case "age":
+			if in.IsNull() {
+				in.Skip()
+				out.Age = nil
+			} else {
+				if out.Age == nil {
+					out.Age = new(int)
+				}
+				*out.Age = int(in.Int())
+			}
+		case "collar":
+			if in.IsNull() {
+				in.Skip()
+				out.Collar = nil
+			} else {
+				if out.Collar == nil {
+					out.Collar = new(int)
+				}
+				*out.Collar = int(in.Int())
+			}
+		case "categories":
+			if in.IsNull() {
+				in.Skip()
+				out.Categories = nil
+			} else {
+				in.Delim('[')
+				if out.Categories == nil {
+					if !in.IsDelim(']') {
+						out.Categories = make([]uint64, 0, 8)
+					} else {
+						out.Categories = []uint64{}
+					}
+				} else {
+					out.Categories = (out.Categories)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v10 uint64
+					v10 = uint64(in.Uint64())
+					out.Categories = append(out.Categories, v10)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "owner":
+			if in.IsNull() {
+				in.Skip()
+				out.Owner = nil
+			} else {
+				if out.Owner == nil {
+					out.Owner = new(uuid.UUID)
+				}
+				if data := in.UnsafeBytes(); in.Ok() {
+					in.AddError((*out.Owner).UnmarshalText(data))
+				}
+			}
+		case "friends":
+			if in.IsNull() {
+				in.Skip()
+				out.Friends = nil
+			} else {
+				in.Delim('[')
+				if out.Friends == nil {
+					if !in.IsDelim(']') {
+						out.Friends = make([]string, 0, 4)
+					} else {
+						out.Friends = []string{}
+					}
+				} else {
+					out.Friends = (out.Friends)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v11 string
+					v11 = string(in.String())
+					out.Friends = append(out.Friends, v11)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwriter.Writer, in PetCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		if in.Name == nil {
+			out.RawString("null")
+		} else {
+			out.String(string(*in.Name))
+		}
+	}
+	{
+		const prefix string = ",\"age\":"
+		out.RawString(prefix)
+		if in.Age == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Age))
+		}
+	}
+	{
+		const prefix string = ",\"collar\":"
+		out.RawString(prefix)
+		if in.Collar == nil {
+			out.RawString("null")
+		} else {
+			out.Int(int(*in.Collar))
+		}
+	}
+	{
+		const prefix string = ",\"categories\":"
+		out.RawString(prefix)
+		if in.Categories == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v12, v13 := range in.Categories {
+				if v12 > 0 {
+					out.RawByte(',')
+				}
+				out.Uint64(uint64(v13))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"owner\":"
+		out.RawString(prefix)
+		if in.Owner == nil {
+			out.RawString("null")
+		} else {
+			out.RawText((*in.Owner).MarshalText())
+		}
+	}
+	{
+		const prefix string = ",\"friends\":"
+		out.RawString(prefix)
+		if in.Friends == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v14, v15 := range in.Friends {
+				if v14 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v15))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet359800019View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexer.Lexer, out *Pet1876743790Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexer.Lexer, out *OwnerViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -583,21 +583,21 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexe
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Pet1876743790Views, 0, 8)
+				*out = make(OwnerViews, 0, 8)
 			} else {
-				*out = Pet1876743790Views{}
+				*out = OwnerViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v16 *Pet1876743790View
+			var v16 *OwnerView
 			if in.IsNull() {
 				in.Skip()
 				v16 = nil
 			} else {
 				if v16 == nil {
-					v16 = new(Pet1876743790View)
+					v16 = new(OwnerView)
 				}
 				(*v16).UnmarshalEasyJSON(in)
 			}
@@ -610,7 +610,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(out *jwriter.Writer, in Pet1876743790Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(out *jwriter.Writer, in OwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
@@ -630,15 +630,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet1876743790Views) MarshalEasyJSON(w *jwriter.Writer) {
+func (v OwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet1876743790Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *OwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(in *jlexer.Lexer, out *Pet1876743790View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(in *jlexer.Lexer, out *OwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -658,23 +658,13 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(in *jlexe
 		}
 		switch key {
 		case "id":
-			out.ID = string(in.String())
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.ID).UnmarshalText(data))
+			}
 		case "name":
 			out.Name = string(in.String())
 		case "age":
 			out.Age = int(in.Int())
-		case "owner":
-			if in.IsNull() {
-				in.Skip()
-				out.Owner = nil
-			} else {
-				if out.Owner == nil {
-					out.Owner = new(Owner139708381View)
-				}
-				(*out.Owner).UnmarshalEasyJSON(in)
-			}
-		case "friends":
-			(out.Friends).UnmarshalEasyJSON(in)
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -689,15 +679,15 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(out *jwriter.Writer, in Pet1876743790View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(out *jwriter.Writer, in OwnerView) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.ID != "" {
+	if true {
 		const prefix string = ",\"id\":"
 		first = false
 		out.RawString(prefix[1:])
-		out.String(string(in.ID))
+		out.RawText((in.ID).MarshalText())
 	}
 	if in.Name != "" {
 		const prefix string = ",\"name\":"
@@ -719,36 +709,16 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(out *jwri
 		}
 		out.Int(int(in.Age))
 	}
-	if in.Owner != nil {
-		const prefix string = ",\"owner\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(*in.Owner).MarshalEasyJSON(out)
-	}
-	if len(in.Friends) != 0 {
-		const prefix string = ",\"friends\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(in.Friends).MarshalEasyJSON(out)
-	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Pet1876743790View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v OwnerView) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Pet1876743790View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *OwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(l, v)
 }
 func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp6(in *jlexer.Lexer, out *OwnerUpdateRequest) {
@@ -1003,154 +973,7 @@ func (v OwnerCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *OwnerCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp7(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(in *jlexer.Lexer, out *Owner139708381Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Owner139708381Views, 0, 8)
-			} else {
-				*out = Owner139708381Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v25 *Owner139708381View
-			if in.IsNull() {
-				in.Skip()
-				v25 = nil
-			} else {
-				if v25 == nil {
-					v25 = new(Owner139708381View)
-				}
-				(*v25).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v25)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(out *jwriter.Writer, in Owner139708381Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v26, v27 := range in {
-			if v26 > 0 {
-				out.RawByte(',')
-			}
-			if v27 == nil {
-				out.RawString("null")
-			} else {
-				(*v27).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Owner139708381Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Owner139708381Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(in *jlexer.Lexer, out *Owner139708381View) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			if data := in.UnsafeBytes(); in.Ok() {
-				in.AddError((out.ID).UnmarshalText(data))
-			}
-		case "name":
-			out.Name = string(in.String())
-		case "age":
-			out.Age = int(in.Int())
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(out *jwriter.Writer, in Owner139708381View) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if true {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.RawText((in.ID).MarshalText())
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
-	}
-	if in.Age != 0 {
-		const prefix string = ",\"age\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.Int(int(in.Age))
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Owner139708381View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Owner139708381View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(in *jlexer.Lexer, out *ErrResponse) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(in *jlexer.Lexer, out *ErrResponse) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1195,7 +1018,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(out *jwriter.Writer, in ErrResponse) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(out *jwriter.Writer, in ErrResponse) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1225,11 +1048,144 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ErrResponse) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ErrResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(in *jlexer.Lexer, out *CollarViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(CollarViews, 0, 8)
+			} else {
+				*out = CollarViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v25 *CollarView
+			if in.IsNull() {
+				in.Skip()
+				v25 = nil
+			} else {
+				if v25 == nil {
+					v25 = new(CollarView)
+				}
+				(*v25).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v25)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(out *jwriter.Writer, in CollarViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v26, v27 := range in {
+			if v26 > 0 {
+				out.RawByte(',')
+			}
+			if v27 == nil {
+				out.RawString("null")
+			} else {
+				(*v27).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(in *jlexer.Lexer, out *CollarView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "color":
+			out.Color = collar.Color(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(out *jwriter.Writer, in CollarView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarView) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(l, v)
 }
 func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp11(in *jlexer.Lexer, out *CollarUpdateRequest) {
@@ -1406,7 +1362,7 @@ func (v CollarCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *CollarCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp12(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlexer.Lexer, out *Collar1522160880Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlexer.Lexer, out *CategoryViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -1415,21 +1371,21 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlex
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(Collar1522160880Views, 0, 8)
+				*out = make(CategoryViews, 0, 8)
 			} else {
-				*out = Collar1522160880Views{}
+				*out = CategoryViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v28 *Collar1522160880View
+			var v28 *CategoryView
 			if in.IsNull() {
 				in.Skip()
 				v28 = nil
 			} else {
 				if v28 == nil {
-					v28 = new(Collar1522160880View)
+					v28 = new(CategoryView)
 				}
 				(*v28).UnmarshalEasyJSON(in)
 			}
@@ -1442,7 +1398,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(out *jwriter.Writer, in Collar1522160880Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(out *jwriter.Writer, in CategoryViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
@@ -1462,15 +1418,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(out *jwr
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Collar1522160880Views) MarshalEasyJSON(w *jwriter.Writer) {
+func (v CategoryViews) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Collar1522160880Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *CategoryViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(in *jlexer.Lexer, out *Collar1522160880View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(in *jlexer.Lexer, out *CategoryView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1490,9 +1446,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(in *jlex
 		}
 		switch key {
 		case "id":
-			out.ID = int(in.Int())
-		case "color":
-			out.Color = collar.Color(in.String())
+			out.ID = uint64(in.Uint64())
+		case "name":
+			out.Name = string(in.String())
 		default:
 			in.AddError(&jlexer.LexerError{
 				Offset: in.GetPos(),
@@ -1507,7 +1463,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(out *jwriter.Writer, in Collar1522160880View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(out *jwriter.Writer, in CategoryView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1515,28 +1471,28 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(out *jwr
 		const prefix string = ",\"id\":"
 		first = false
 		out.RawString(prefix[1:])
-		out.Int(int(in.ID))
+		out.Uint64(uint64(in.ID))
 	}
-	if in.Color != "" {
-		const prefix string = ",\"color\":"
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Color))
+		out.String(string(in.Name))
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Collar1522160880View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v CategoryView) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Collar1522160880View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *CategoryView) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(l, v)
 }
 func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp15(in *jlexer.Lexer, out *CategoryUpdateRequest) {
@@ -1752,137 +1708,4 @@ func (v CategoryCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CategoryCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp16(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp17(in *jlexer.Lexer, out *Category4094953247Views) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		in.Skip()
-		*out = nil
-	} else {
-		in.Delim('[')
-		if *out == nil {
-			if !in.IsDelim(']') {
-				*out = make(Category4094953247Views, 0, 8)
-			} else {
-				*out = Category4094953247Views{}
-			}
-		} else {
-			*out = (*out)[:0]
-		}
-		for !in.IsDelim(']') {
-			var v37 *Category4094953247View
-			if in.IsNull() {
-				in.Skip()
-				v37 = nil
-			} else {
-				if v37 == nil {
-					v37 = new(Category4094953247View)
-				}
-				(*v37).UnmarshalEasyJSON(in)
-			}
-			*out = append(*out, v37)
-			in.WantComma()
-		}
-		in.Delim(']')
-	}
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp17(out *jwriter.Writer, in Category4094953247Views) {
-	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
-		out.RawString("null")
-	} else {
-		out.RawByte('[')
-		for v38, v39 := range in {
-			if v38 > 0 {
-				out.RawByte(',')
-			}
-			if v39 == nil {
-				out.RawString("null")
-			} else {
-				(*v39).MarshalEasyJSON(out)
-			}
-		}
-		out.RawByte(']')
-	}
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Category4094953247Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp17(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Category4094953247Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp17(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp18(in *jlexer.Lexer, out *Category4094953247View) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			out.ID = uint64(in.Uint64())
-		case "name":
-			out.Name = string(in.String())
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp18(out *jwriter.Writer, in Category4094953247View) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.ID != 0 {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.Uint64(uint64(in.ID))
-	}
-	if in.Name != "" {
-		const prefix string = ",\"name\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.Name))
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Category4094953247View) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp18(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Category4094953247View) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp18(l, v)
 }

--- a/internal/simple/ent/http/easyjson.go
+++ b/internal/simple/ent/http/easyjson.go
@@ -19,7 +19,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(in *jlexer.Lexer, out *PetViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(in *jlexer.Lexer, out *PetWithOwnerAndPetOwnerViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -28,21 +28,21 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(in *jlexer
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(PetViews, 0, 8)
+				*out = make(PetWithOwnerAndPetOwnerViews, 0, 8)
 			} else {
-				*out = PetViews{}
+				*out = PetWithOwnerAndPetOwnerViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v1 *PetView
+			var v1 *PetWithOwnerAndPetOwnerView
 			if in.IsNull() {
 				in.Skip()
 				v1 = nil
 			} else {
 				if v1 == nil {
-					v1 = new(PetView)
+					v1 = new(PetWithOwnerAndPetOwnerView)
 				}
 				(*v1).UnmarshalEasyJSON(in)
 			}
@@ -55,7 +55,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(out *jwriter.Writer, in PetViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(out *jwriter.Writer, in PetWithOwnerAndPetOwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
@@ -75,15 +75,192 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(out *jwrit
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v PetViews) MarshalEasyJSON(w *jwriter.Writer) {
+func (v PetWithOwnerAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *PetViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *PetWithOwnerAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(in *jlexer.Lexer, out *PetView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(in *jlexer.Lexer, out *PetWithOwnerAndPetOwnerView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = string(in.String())
+		case "name":
+			out.Name = string(in.String())
+		case "age":
+			out.Age = int(in.Int())
+		case "owner":
+			if in.IsNull() {
+				in.Skip()
+				out.Owner = nil
+			} else {
+				if out.Owner == nil {
+					out.Owner = new(OwnerWithPetAndPetOwnerView)
+				}
+				(*out.Owner).UnmarshalEasyJSON(in)
+			}
+		case "friends":
+			(out.Friends).UnmarshalEasyJSON(in)
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(out *jwriter.Writer, in PetWithOwnerAndPetOwnerView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != "" {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.ID))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if in.Age != 0 {
+		const prefix string = ",\"age\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.Age))
+	}
+	if in.Owner != nil {
+		const prefix string = ",\"owner\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Owner).MarshalEasyJSON(out)
+	}
+	if len(in.Friends) != 0 {
+		const prefix string = ",\"friends\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.Friends).MarshalEasyJSON(out)
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetWithOwnerAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetWithOwnerAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexer.Lexer, out *PetViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(PetViews, 0, 8)
+			} else {
+				*out = PetViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v4 *PetView
+			if in.IsNull() {
+				in.Skip()
+				v4 = nil
+			} else {
+				if v4 == nil {
+					v4 = new(PetView)
+				}
+				(*v4).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v4)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwriter.Writer, in PetViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v5, v6 := range in {
+			if v5 > 0 {
+				out.RawByte(',')
+			}
+			if v6 == nil {
+				out.RawString("null")
+			} else {
+				(*v6).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v PetViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *PetViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexer.Lexer, out *PetView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -122,7 +299,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(out *jwriter.Writer, in PetView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwriter.Writer, in PetView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -157,14 +334,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(out *jwri
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp1(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp1(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexer.Lexer, out *PetUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexer.Lexer, out *PetUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -229,9 +406,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexe
 					out.Categories = (out.Categories)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v4 uint64
-					v4 = uint64(in.Uint64())
-					out.Categories = append(out.Categories, v4)
+					var v7 uint64
+					v7 = uint64(in.Uint64())
+					out.Categories = append(out.Categories, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -264,9 +441,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexe
 					out.Friends = (out.Friends)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v5 string
-					v5 = string(in.String())
-					out.Friends = append(out.Friends, v5)
+					var v8 string
+					v8 = string(in.String())
+					out.Friends = append(out.Friends, v8)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -285,7 +462,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwriter.Writer, in PetUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(out *jwriter.Writer, in PetUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -323,11 +500,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v6, v7 := range in.Categories {
-				if v6 > 0 {
+			for v9, v10 := range in.Categories {
+				if v9 > 0 {
 					out.RawByte(',')
 				}
-				out.Uint64(uint64(v7))
+				out.Uint64(uint64(v10))
 			}
 			out.RawByte(']')
 		}
@@ -348,11 +525,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v8, v9 := range in.Friends {
-				if v8 > 0 {
+			for v11, v12 := range in.Friends {
+				if v11 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v9))
+				out.String(string(v12))
 			}
 			out.RawByte(']')
 		}
@@ -362,14 +539,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(out *jwri
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp2(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp2(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexer.Lexer, out *PetCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(in *jlexer.Lexer, out *PetCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -434,9 +611,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexe
 					out.Categories = (out.Categories)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v10 uint64
-					v10 = uint64(in.Uint64())
-					out.Categories = append(out.Categories, v10)
+					var v13 uint64
+					v13 = uint64(in.Uint64())
+					out.Categories = append(out.Categories, v13)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -469,9 +646,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexe
 					out.Friends = (out.Friends)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v11 string
-					v11 = string(in.String())
-					out.Friends = append(out.Friends, v11)
+					var v14 string
+					v14 = string(in.String())
+					out.Friends = append(out.Friends, v14)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -490,7 +667,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwriter.Writer, in PetCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(out *jwriter.Writer, in PetCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -528,11 +705,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v12, v13 := range in.Categories {
-				if v12 > 0 {
+			for v15, v16 := range in.Categories {
+				if v15 > 0 {
 					out.RawByte(',')
 				}
-				out.Uint64(uint64(v13))
+				out.Uint64(uint64(v16))
 			}
 			out.RawByte(']')
 		}
@@ -553,11 +730,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v14, v15 := range in.Friends {
-				if v14 > 0 {
+			for v17, v18 := range in.Friends {
+				if v17 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v15))
+				out.String(string(v18))
 			}
 			out.RawByte(']')
 		}
@@ -567,14 +744,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(out *jwri
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PetCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp3(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PetCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp3(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexer.Lexer, out *OwnerViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp6(in *jlexer.Lexer, out *OwnerWithPetAndPetOwnerViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -583,25 +760,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexe
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(OwnerViews, 0, 8)
+				*out = make(OwnerWithPetAndPetOwnerViews, 0, 8)
 			} else {
-				*out = OwnerViews{}
+				*out = OwnerWithPetAndPetOwnerViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v16 *OwnerView
+			var v19 *OwnerWithPetAndPetOwnerView
 			if in.IsNull() {
 				in.Skip()
-				v16 = nil
+				v19 = nil
 			} else {
-				if v16 == nil {
-					v16 = new(OwnerView)
+				if v19 == nil {
+					v19 = new(OwnerWithPetAndPetOwnerView)
 				}
-				(*v16).UnmarshalEasyJSON(in)
+				(*v19).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v16)
+			*out = append(*out, v19)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -610,19 +787,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(out *jwriter.Writer, in OwnerViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp6(out *jwriter.Writer, in OwnerWithPetAndPetOwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v17, v18 := range in {
-			if v17 > 0 {
+		for v20, v21 := range in {
+			if v20 > 0 {
 				out.RawByte(',')
 			}
-			if v18 == nil {
+			if v21 == nil {
 				out.RawString("null")
 			} else {
-				(*v18).MarshalEasyJSON(out)
+				(*v21).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -630,15 +807,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v OwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp4(w, v)
+func (v OwnerWithPetAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp6(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *OwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp4(l, v)
+func (v *OwnerWithPetAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp6(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(in *jlexer.Lexer, out *OwnerView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp7(in *jlexer.Lexer, out *OwnerWithPetAndPetOwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -679,7 +856,154 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(out *jwriter.Writer, in OwnerView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp7(out *jwriter.Writer, in OwnerWithPetAndPetOwnerView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if true {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.RawText((in.ID).MarshalText())
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	if in.Age != 0 {
+		const prefix string = ",\"age\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.Age))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v OwnerWithPetAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp7(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *OwnerWithPetAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp7(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(in *jlexer.Lexer, out *OwnerViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(OwnerViews, 0, 8)
+			} else {
+				*out = OwnerViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v22 *OwnerView
+			if in.IsNull() {
+				in.Skip()
+				v22 = nil
+			} else {
+				if v22 == nil {
+					v22 = new(OwnerView)
+				}
+				(*v22).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v22)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(out *jwriter.Writer, in OwnerViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v23, v24 := range in {
+			if v23 > 0 {
+				out.RawByte(',')
+			}
+			if v24 == nil {
+				out.RawString("null")
+			} else {
+				(*v24).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v OwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *OwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(in *jlexer.Lexer, out *OwnerView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			if data := in.UnsafeBytes(); in.Ok() {
+				in.AddError((out.ID).UnmarshalText(data))
+			}
+		case "name":
+			out.Name = string(in.String())
+		case "age":
+			out.Age = int(in.Int())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(out *jwriter.Writer, in OwnerView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -714,14 +1038,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(out *jwri
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v OwnerView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp5(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *OwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp5(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp6(in *jlexer.Lexer, out *OwnerUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(in *jlexer.Lexer, out *OwnerUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -776,9 +1100,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp6(in *jlexe
 					out.Pets = (out.Pets)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v19 string
-					v19 = string(in.String())
-					out.Pets = append(out.Pets, v19)
+					var v25 string
+					v25 = string(in.String())
+					out.Pets = append(out.Pets, v25)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -797,7 +1121,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp6(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp6(out *jwriter.Writer, in OwnerUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(out *jwriter.Writer, in OwnerUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -826,11 +1150,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp6(out *jwri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v20, v21 := range in.Pets {
-				if v20 > 0 {
+			for v26, v27 := range in.Pets {
+				if v26 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v21))
+				out.String(string(v27))
 			}
 			out.RawByte(']')
 		}
@@ -840,14 +1164,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp6(out *jwri
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v OwnerUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp6(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *OwnerUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp6(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp7(in *jlexer.Lexer, out *OwnerCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp11(in *jlexer.Lexer, out *OwnerCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -902,9 +1226,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp7(in *jlexe
 					out.Pets = (out.Pets)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v22 string
-					v22 = string(in.String())
-					out.Pets = append(out.Pets, v22)
+					var v28 string
+					v28 = string(in.String())
+					out.Pets = append(out.Pets, v28)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -923,7 +1247,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp7(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp7(out *jwriter.Writer, in OwnerCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp11(out *jwriter.Writer, in OwnerCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -952,11 +1276,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp7(out *jwri
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v23, v24 := range in.Pets {
-				if v23 > 0 {
+			for v29, v30 := range in.Pets {
+				if v29 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v24))
+				out.String(string(v30))
 			}
 			out.RawByte(']')
 		}
@@ -966,14 +1290,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp7(out *jwri
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v OwnerCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp7(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp11(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *OwnerCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp7(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp11(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(in *jlexer.Lexer, out *ErrResponse) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp12(in *jlexer.Lexer, out *ErrResponse) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1018,7 +1342,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(out *jwriter.Writer, in ErrResponse) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp12(out *jwriter.Writer, in ErrResponse) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1048,14 +1372,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(out *jwri
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ErrResponse) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp8(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp12(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ErrResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp8(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp12(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(in *jlexer.Lexer, out *CollarViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlexer.Lexer, out *CollarWithOwnerAndPetAndPetOwnerViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -1064,25 +1388,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(in *jlexe
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(CollarViews, 0, 8)
+				*out = make(CollarWithOwnerAndPetAndPetOwnerViews, 0, 8)
 			} else {
-				*out = CollarViews{}
+				*out = CollarWithOwnerAndPetAndPetOwnerViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v25 *CollarView
+			var v31 *CollarWithOwnerAndPetAndPetOwnerView
 			if in.IsNull() {
 				in.Skip()
-				v25 = nil
+				v31 = nil
 			} else {
-				if v25 == nil {
-					v25 = new(CollarView)
+				if v31 == nil {
+					v31 = new(CollarWithOwnerAndPetAndPetOwnerView)
 				}
-				(*v25).UnmarshalEasyJSON(in)
+				(*v31).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v25)
+			*out = append(*out, v31)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -1091,19 +1415,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(in *jlexe
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(out *jwriter.Writer, in CollarViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(out *jwriter.Writer, in CollarWithOwnerAndPetAndPetOwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v26, v27 := range in {
-			if v26 > 0 {
+		for v32, v33 := range in {
+			if v32 > 0 {
 				out.RawByte(',')
 			}
-			if v27 == nil {
+			if v33 == nil {
 				out.RawString("null")
 			} else {
-				(*v27).MarshalEasyJSON(out)
+				(*v33).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -1111,15 +1435,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(out *jwri
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CollarViews) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp9(w, v)
+func (v CollarWithOwnerAndPetAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CollarViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp9(l, v)
+func (v *CollarWithOwnerAndPetAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(in *jlexer.Lexer, out *CollarView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(in *jlexer.Lexer, out *CollarWithOwnerAndPetAndPetOwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1156,7 +1480,140 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(out *jwriter.Writer, in CollarView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(out *jwriter.Writer, in CollarWithOwnerAndPetAndPetOwnerView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Int(int(in.ID))
+	}
+	if in.Color != "" {
+		const prefix string = ",\"color\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Color))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarWithOwnerAndPetAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarWithOwnerAndPetAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp15(in *jlexer.Lexer, out *CollarViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(CollarViews, 0, 8)
+			} else {
+				*out = CollarViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v34 *CollarView
+			if in.IsNull() {
+				in.Skip()
+				v34 = nil
+			} else {
+				if v34 == nil {
+					v34 = new(CollarView)
+				}
+				(*v34).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v34)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp15(out *jwriter.Writer, in CollarViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v35, v36 := range in {
+			if v35 > 0 {
+				out.RawByte(',')
+			}
+			if v36 == nil {
+				out.RawString("null")
+			} else {
+				(*v36).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CollarViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp15(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CollarViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp15(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp16(in *jlexer.Lexer, out *CollarView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = int(in.Int())
+		case "color":
+			out.Color = collar.Color(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp16(out *jwriter.Writer, in CollarView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1181,14 +1638,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CollarView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp10(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp16(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CollarView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp10(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp16(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp11(in *jlexer.Lexer, out *CollarUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp17(in *jlexer.Lexer, out *CollarUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1241,7 +1698,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp11(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp11(out *jwriter.Writer, in CollarUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp17(out *jwriter.Writer, in CollarUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1268,14 +1725,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp11(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CollarUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp11(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp17(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CollarUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp11(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp17(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp12(in *jlexer.Lexer, out *CollarCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp18(in *jlexer.Lexer, out *CollarCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1328,7 +1785,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp12(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp12(out *jwriter.Writer, in CollarCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp18(out *jwriter.Writer, in CollarCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1355,14 +1812,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp12(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CollarCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp12(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp18(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CollarCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp12(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp18(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlexer.Lexer, out *CategoryViews) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp19(in *jlexer.Lexer, out *CategoryWithOwnerAndPetAndPetOwnerViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -1371,25 +1828,25 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlex
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(CategoryViews, 0, 8)
+				*out = make(CategoryWithOwnerAndPetAndPetOwnerViews, 0, 8)
 			} else {
-				*out = CategoryViews{}
+				*out = CategoryWithOwnerAndPetAndPetOwnerViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v28 *CategoryView
+			var v37 *CategoryWithOwnerAndPetAndPetOwnerView
 			if in.IsNull() {
 				in.Skip()
-				v28 = nil
+				v37 = nil
 			} else {
-				if v28 == nil {
-					v28 = new(CategoryView)
+				if v37 == nil {
+					v37 = new(CategoryWithOwnerAndPetAndPetOwnerView)
 				}
-				(*v28).UnmarshalEasyJSON(in)
+				(*v37).UnmarshalEasyJSON(in)
 			}
-			*out = append(*out, v28)
+			*out = append(*out, v37)
 			in.WantComma()
 		}
 		in.Delim(']')
@@ -1398,19 +1855,19 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(out *jwriter.Writer, in CategoryViews) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp19(out *jwriter.Writer, in CategoryWithOwnerAndPetAndPetOwnerViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
 		out.RawByte('[')
-		for v29, v30 := range in {
-			if v29 > 0 {
+		for v38, v39 := range in {
+			if v38 > 0 {
 				out.RawByte(',')
 			}
-			if v30 == nil {
+			if v39 == nil {
 				out.RawString("null")
 			} else {
-				(*v30).MarshalEasyJSON(out)
+				(*v39).MarshalEasyJSON(out)
 			}
 		}
 		out.RawByte(']')
@@ -1418,15 +1875,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(out *jwr
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CategoryViews) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp13(w, v)
+func (v CategoryWithOwnerAndPetAndPetOwnerViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp19(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CategoryViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp13(l, v)
+func (v *CategoryWithOwnerAndPetAndPetOwnerViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp19(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(in *jlexer.Lexer, out *CategoryView) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp20(in *jlexer.Lexer, out *CategoryWithOwnerAndPetAndPetOwnerView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1463,7 +1920,140 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(out *jwriter.Writer, in CategoryView) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp20(out *jwriter.Writer, in CategoryWithOwnerAndPetAndPetOwnerView) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.ID != 0 {
+		const prefix string = ",\"id\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.Uint64(uint64(in.ID))
+	}
+	if in.Name != "" {
+		const prefix string = ",\"name\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Name))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CategoryWithOwnerAndPetAndPetOwnerView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp20(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CategoryWithOwnerAndPetAndPetOwnerView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp20(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp21(in *jlexer.Lexer, out *CategoryViews) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		in.Skip()
+		*out = nil
+	} else {
+		in.Delim('[')
+		if *out == nil {
+			if !in.IsDelim(']') {
+				*out = make(CategoryViews, 0, 8)
+			} else {
+				*out = CategoryViews{}
+			}
+		} else {
+			*out = (*out)[:0]
+		}
+		for !in.IsDelim(']') {
+			var v40 *CategoryView
+			if in.IsNull() {
+				in.Skip()
+				v40 = nil
+			} else {
+				if v40 == nil {
+					v40 = new(CategoryView)
+				}
+				(*v40).UnmarshalEasyJSON(in)
+			}
+			*out = append(*out, v40)
+			in.WantComma()
+		}
+		in.Delim(']')
+	}
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp21(out *jwriter.Writer, in CategoryViews) {
+	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		out.RawString("null")
+	} else {
+		out.RawByte('[')
+		for v41, v42 := range in {
+			if v41 > 0 {
+				out.RawByte(',')
+			}
+			if v42 == nil {
+				out.RawString("null")
+			} else {
+				(*v42).MarshalEasyJSON(out)
+			}
+		}
+		out.RawByte(']')
+	}
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CategoryViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp21(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CategoryViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp21(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp22(in *jlexer.Lexer, out *CategoryView) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "id":
+			out.ID = uint64(in.Uint64())
+		case "name":
+			out.Name = string(in.String())
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp22(out *jwriter.Writer, in CategoryView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1488,14 +2078,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CategoryView) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp14(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp22(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CategoryView) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp14(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp22(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp15(in *jlexer.Lexer, out *CategoryUpdateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp23(in *jlexer.Lexer, out *CategoryUpdateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1540,9 +2130,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp15(in *jlex
 					out.Pets = (out.Pets)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v31 string
-					v31 = string(in.String())
-					out.Pets = append(out.Pets, v31)
+					var v43 string
+					v43 = string(in.String())
+					out.Pets = append(out.Pets, v43)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1561,7 +2151,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp15(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp15(out *jwriter.Writer, in CategoryUpdateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp23(out *jwriter.Writer, in CategoryUpdateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1581,11 +2171,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp15(out *jwr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v32, v33 := range in.Pets {
-				if v32 > 0 {
+			for v44, v45 := range in.Pets {
+				if v44 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v33))
+				out.String(string(v45))
 			}
 			out.RawByte(']')
 		}
@@ -1595,14 +2185,14 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp15(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CategoryUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp15(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp23(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CategoryUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp15(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp23(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp16(in *jlexer.Lexer, out *CategoryCreateRequest) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp24(in *jlexer.Lexer, out *CategoryCreateRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1647,9 +2237,9 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp16(in *jlex
 					out.Pets = (out.Pets)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v34 string
-					v34 = string(in.String())
-					out.Pets = append(out.Pets, v34)
+					var v46 string
+					v46 = string(in.String())
+					out.Pets = append(out.Pets, v46)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1668,7 +2258,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp16(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp16(out *jwriter.Writer, in CategoryCreateRequest) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp24(out *jwriter.Writer, in CategoryCreateRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1688,11 +2278,11 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp16(out *jwr
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v35, v36 := range in.Pets {
-				if v35 > 0 {
+			for v47, v48 := range in.Pets {
+				if v47 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v36))
+				out.String(string(v48))
 			}
 			out.RawByte(']')
 		}
@@ -1702,10 +2292,10 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp16(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CategoryCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp16(w, v)
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalSimpleEntHttp24(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CategoryCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp16(l, v)
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalSimpleEntHttp24(l, v)
 }

--- a/internal/simple/ent/http/list.go
+++ b/internal/simple/ent/http/list.go
@@ -41,7 +41,7 @@ func (h *CategoryHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("categories rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryViews(es), w)
 }
 
 // Read fetches the ent.Collar identified by a given url-parameter from the
@@ -75,7 +75,7 @@ func (h *CollarHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collars rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarViews(es), w)
 }
 
 // Read fetches the ent.Owner identified by a given url-parameter from the
@@ -109,7 +109,7 @@ func (h *OwnerHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owners rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerViews(es), w)
 }
 
 // Read fetches the ent.Pet identified by a given url-parameter from the
@@ -143,5 +143,5 @@ func (h *PetHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }

--- a/internal/simple/ent/http/read.go
+++ b/internal/simple/ent/http/read.go
@@ -155,5 +155,5 @@ func (h *PetHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetWithOwnerAndPetOwnerView(e), w)
 }

--- a/internal/simple/ent/http/read.go
+++ b/internal/simple/ent/http/read.go
@@ -49,7 +49,7 @@ func (h *CategoryHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("category rendered", zap.Uint64("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(e), w)
 }
 
 // Read fetches the ent.Collar identified by a given url-parameter from the
@@ -83,7 +83,7 @@ func (h *CollarHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collar rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
 }
 
 // Read fetches the ent.Owner identified by a given url-parameter from the
@@ -117,7 +117,7 @@ func (h *OwnerHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owner rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
 }
 
 // Read fetches the ent.Pet identified by a given url-parameter from the
@@ -155,5 +155,5 @@ func (h *PetHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet1876743790View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }

--- a/internal/simple/ent/http/relations.go
+++ b/internal/simple/ent/http/relations.go
@@ -56,7 +56,7 @@ func (h CategoryHandler) Pets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // Pet fetches the ent.pet attached to the ent.Collar
@@ -98,7 +98,7 @@ func (h CollarHandler) Pet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPet1876743790View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }
 
 // Pets fetches the ent.pets attached to the ent.Owner
@@ -139,7 +139,7 @@ func (h OwnerHandler) Pets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }
 
 // Collar fetches the ent.collar attached to the ent.Pet
@@ -169,7 +169,7 @@ func (h PetHandler) Collar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collar rendered", zap.Int("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
 }
 
 // Categories fetches the ent.categories attached to the ent.Pet
@@ -206,7 +206,7 @@ func (h PetHandler) Categories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("categories rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryViews(es), w)
 }
 
 // Owner fetches the ent.owner attached to the ent.Pet
@@ -236,7 +236,7 @@ func (h PetHandler) Owner(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owner rendered", zap.String("id", e.ID.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
 }
 
 // Friends fetches the ent.friends attached to the ent.Pet
@@ -273,5 +273,5 @@ func (h PetHandler) Friends(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pets rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetViews(es), w)
 }

--- a/internal/simple/ent/http/relations.go
+++ b/internal/simple/ent/http/relations.go
@@ -98,7 +98,7 @@ func (h CollarHandler) Pet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", e.ID))
-	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetWithOwnerAndPetOwnerView(e), w)
 }
 
 // Pets fetches the ent.pets attached to the ent.Owner

--- a/internal/simple/ent/http/response.go
+++ b/internal/simple/ent/http/response.go
@@ -81,7 +81,6 @@ func Unauthorized(w http.ResponseWriter, msg interface{}) (int, error) {
 type (
 	// CategoryView represents the data serialized for the following serialization group combinations:
 	// []
-	// [owner pet pet:owner]
 	CategoryView struct {
 		ID   uint64 `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
@@ -111,9 +110,39 @@ func NewCategoryViews(es []*ent.Category) CategoryViews {
 }
 
 type (
+	// CategoryWithOwnerAndPetAndPetOwnerView represents the data serialized for the following serialization group combinations:
+	// [owner pet pet:owner]
+	CategoryWithOwnerAndPetAndPetOwnerView struct {
+		ID   uint64 `json:"id,omitempty"`
+		Name string `json:"name,omitempty"`
+	}
+	CategoryWithOwnerAndPetAndPetOwnerViews []*CategoryWithOwnerAndPetAndPetOwnerView
+)
+
+func NewCategoryWithOwnerAndPetAndPetOwnerView(e *ent.Category) *CategoryWithOwnerAndPetAndPetOwnerView {
+	if e == nil {
+		return nil
+	}
+	return &CategoryWithOwnerAndPetAndPetOwnerView{
+		ID:   e.ID,
+		Name: e.Name,
+	}
+}
+
+func NewCategoryWithOwnerAndPetAndPetOwnerViews(es []*ent.Category) CategoryWithOwnerAndPetAndPetOwnerViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(CategoryWithOwnerAndPetAndPetOwnerViews, len(es))
+	for i, e := range es {
+		r[i] = NewCategoryWithOwnerAndPetAndPetOwnerView(e)
+	}
+	return r
+}
+
+type (
 	// CollarView represents the data serialized for the following serialization group combinations:
 	// []
-	// [owner pet pet:owner]
 	CollarView struct {
 		ID    int          `json:"id,omitempty"`
 		Color collar.Color `json:"color,omitempty"`
@@ -143,9 +172,39 @@ func NewCollarViews(es []*ent.Collar) CollarViews {
 }
 
 type (
+	// CollarWithOwnerAndPetAndPetOwnerView represents the data serialized for the following serialization group combinations:
+	// [owner pet pet:owner]
+	CollarWithOwnerAndPetAndPetOwnerView struct {
+		ID    int          `json:"id,omitempty"`
+		Color collar.Color `json:"color,omitempty"`
+	}
+	CollarWithOwnerAndPetAndPetOwnerViews []*CollarWithOwnerAndPetAndPetOwnerView
+)
+
+func NewCollarWithOwnerAndPetAndPetOwnerView(e *ent.Collar) *CollarWithOwnerAndPetAndPetOwnerView {
+	if e == nil {
+		return nil
+	}
+	return &CollarWithOwnerAndPetAndPetOwnerView{
+		ID:    e.ID,
+		Color: e.Color,
+	}
+}
+
+func NewCollarWithOwnerAndPetAndPetOwnerViews(es []*ent.Collar) CollarWithOwnerAndPetAndPetOwnerViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(CollarWithOwnerAndPetAndPetOwnerViews, len(es))
+	for i, e := range es {
+		r[i] = NewCollarWithOwnerAndPetAndPetOwnerView(e)
+	}
+	return r
+}
+
+type (
 	// OwnerView represents the data serialized for the following serialization group combinations:
 	// []
-	// [owner pet pet:owner]
 	OwnerView struct {
 		ID   uuid.UUID `json:"id,omitempty"`
 		Name string    `json:"name,omitempty"`
@@ -177,9 +236,41 @@ func NewOwnerViews(es []*ent.Owner) OwnerViews {
 }
 
 type (
+	// OwnerWithPetAndPetOwnerView represents the data serialized for the following serialization group combinations:
+	// [owner pet pet:owner]
+	OwnerWithPetAndPetOwnerView struct {
+		ID   uuid.UUID `json:"id,omitempty"`
+		Name string    `json:"name,omitempty"`
+		Age  int       `json:"age,omitempty"`
+	}
+	OwnerWithPetAndPetOwnerViews []*OwnerWithPetAndPetOwnerView
+)
+
+func NewOwnerWithPetAndPetOwnerView(e *ent.Owner) *OwnerWithPetAndPetOwnerView {
+	if e == nil {
+		return nil
+	}
+	return &OwnerWithPetAndPetOwnerView{
+		ID:   e.ID,
+		Name: e.Name,
+		Age:  e.Age,
+	}
+}
+
+func NewOwnerWithPetAndPetOwnerViews(es []*ent.Owner) OwnerWithPetAndPetOwnerViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(OwnerWithPetAndPetOwnerViews, len(es))
+	for i, e := range es {
+		r[i] = NewOwnerWithPetAndPetOwnerView(e)
+	}
+	return r
+}
+
+type (
 	// PetView represents the data serialized for the following serialization group combinations:
 	// []
-	// [owner pet pet:owner]
 	PetView struct {
 		ID   string `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
@@ -206,6 +297,43 @@ func NewPetViews(es []*ent.Pet) PetViews {
 	r := make(PetViews, len(es))
 	for i, e := range es {
 		r[i] = NewPetView(e)
+	}
+	return r
+}
+
+type (
+	// PetWithOwnerAndPetOwnerView represents the data serialized for the following serialization group combinations:
+	// [owner pet pet:owner]
+	PetWithOwnerAndPetOwnerView struct {
+		ID      string                       `json:"id,omitempty"`
+		Name    string                       `json:"name,omitempty"`
+		Age     int                          `json:"age,omitempty"`
+		Owner   *OwnerWithPetAndPetOwnerView `json:"owner,omitempty"`
+		Friends PetWithOwnerAndPetOwnerViews `json:"friends,omitempty"`
+	}
+	PetWithOwnerAndPetOwnerViews []*PetWithOwnerAndPetOwnerView
+)
+
+func NewPetWithOwnerAndPetOwnerView(e *ent.Pet) *PetWithOwnerAndPetOwnerView {
+	if e == nil {
+		return nil
+	}
+	return &PetWithOwnerAndPetOwnerView{
+		ID:      e.ID,
+		Name:    e.Name,
+		Age:     e.Age,
+		Owner:   NewOwnerWithPetAndPetOwnerView(e.Edges.Owner),
+		Friends: NewPetWithOwnerAndPetOwnerViews(e.Edges.Friends),
+	}
+}
+
+func NewPetWithOwnerAndPetOwnerViews(es []*ent.Pet) PetWithOwnerAndPetOwnerViews {
+	if len(es) == 0 {
+		return nil
+	}
+	r := make(PetWithOwnerAndPetOwnerViews, len(es))
+	for i, e := range es {
+		r[i] = NewPetWithOwnerAndPetOwnerView(e)
 	}
 	return r
 }

--- a/internal/simple/ent/http/response.go
+++ b/internal/simple/ent/http/response.go
@@ -79,169 +79,133 @@ func Unauthorized(w http.ResponseWriter, msg interface{}) (int, error) {
 }
 
 type (
-	// Category4094953247View represents the data serialized for the following serialization group combinations:
+	// CategoryView represents the data serialized for the following serialization group combinations:
 	// []
 	// [owner pet pet:owner]
-	Category4094953247View struct {
+	CategoryView struct {
 		ID   uint64 `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
 	}
-	Category4094953247Views []*Category4094953247View
+	CategoryViews []*CategoryView
 )
 
-func NewCategory4094953247View(e *ent.Category) *Category4094953247View {
+func NewCategoryView(e *ent.Category) *CategoryView {
 	if e == nil {
 		return nil
 	}
-	return &Category4094953247View{
+	return &CategoryView{
 		ID:   e.ID,
 		Name: e.Name,
 	}
 }
 
-func NewCategory4094953247Views(es []*ent.Category) Category4094953247Views {
+func NewCategoryViews(es []*ent.Category) CategoryViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Category4094953247Views, len(es))
+	r := make(CategoryViews, len(es))
 	for i, e := range es {
-		r[i] = NewCategory4094953247View(e)
+		r[i] = NewCategoryView(e)
 	}
 	return r
 }
 
 type (
-	// Collar1522160880View represents the data serialized for the following serialization group combinations:
+	// CollarView represents the data serialized for the following serialization group combinations:
 	// []
 	// [owner pet pet:owner]
-	Collar1522160880View struct {
+	CollarView struct {
 		ID    int          `json:"id,omitempty"`
 		Color collar.Color `json:"color,omitempty"`
 	}
-	Collar1522160880Views []*Collar1522160880View
+	CollarViews []*CollarView
 )
 
-func NewCollar1522160880View(e *ent.Collar) *Collar1522160880View {
+func NewCollarView(e *ent.Collar) *CollarView {
 	if e == nil {
 		return nil
 	}
-	return &Collar1522160880View{
+	return &CollarView{
 		ID:    e.ID,
 		Color: e.Color,
 	}
 }
 
-func NewCollar1522160880Views(es []*ent.Collar) Collar1522160880Views {
+func NewCollarViews(es []*ent.Collar) CollarViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Collar1522160880Views, len(es))
+	r := make(CollarViews, len(es))
 	for i, e := range es {
-		r[i] = NewCollar1522160880View(e)
+		r[i] = NewCollarView(e)
 	}
 	return r
 }
 
 type (
-	// Owner139708381View represents the data serialized for the following serialization group combinations:
+	// OwnerView represents the data serialized for the following serialization group combinations:
 	// []
 	// [owner pet pet:owner]
-	Owner139708381View struct {
+	OwnerView struct {
 		ID   uuid.UUID `json:"id,omitempty"`
 		Name string    `json:"name,omitempty"`
 		Age  int       `json:"age,omitempty"`
 	}
-	Owner139708381Views []*Owner139708381View
+	OwnerViews []*OwnerView
 )
 
-func NewOwner139708381View(e *ent.Owner) *Owner139708381View {
+func NewOwnerView(e *ent.Owner) *OwnerView {
 	if e == nil {
 		return nil
 	}
-	return &Owner139708381View{
+	return &OwnerView{
 		ID:   e.ID,
 		Name: e.Name,
 		Age:  e.Age,
 	}
 }
 
-func NewOwner139708381Views(es []*ent.Owner) Owner139708381Views {
+func NewOwnerViews(es []*ent.Owner) OwnerViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Owner139708381Views, len(es))
+	r := make(OwnerViews, len(es))
 	for i, e := range es {
-		r[i] = NewOwner139708381View(e)
+		r[i] = NewOwnerView(e)
 	}
 	return r
 }
 
 type (
-	// Pet1876743790View represents the data serialized for the following serialization group combinations:
-	// [owner pet pet:owner]
-	Pet1876743790View struct {
-		ID      string              `json:"id,omitempty"`
-		Name    string              `json:"name,omitempty"`
-		Age     int                 `json:"age,omitempty"`
-		Owner   *Owner139708381View `json:"owner,omitempty"`
-		Friends Pet359800019Views   `json:"friends,omitempty"`
-	}
-	Pet1876743790Views []*Pet1876743790View
-)
-
-func NewPet1876743790View(e *ent.Pet) *Pet1876743790View {
-	if e == nil {
-		return nil
-	}
-	return &Pet1876743790View{
-		ID:      e.ID,
-		Name:    e.Name,
-		Age:     e.Age,
-		Owner:   NewOwner139708381View(e.Edges.Owner),
-		Friends: NewPet359800019Views(e.Edges.Friends),
-	}
-}
-
-func NewPet1876743790Views(es []*ent.Pet) Pet1876743790Views {
-	if len(es) == 0 {
-		return nil
-	}
-	r := make(Pet1876743790Views, len(es))
-	for i, e := range es {
-		r[i] = NewPet1876743790View(e)
-	}
-	return r
-}
-
-type (
-	// Pet359800019View represents the data serialized for the following serialization group combinations:
+	// PetView represents the data serialized for the following serialization group combinations:
 	// []
-	Pet359800019View struct {
+	// [owner pet pet:owner]
+	PetView struct {
 		ID   string `json:"id,omitempty"`
 		Name string `json:"name,omitempty"`
 		Age  int    `json:"age,omitempty"`
 	}
-	Pet359800019Views []*Pet359800019View
+	PetViews []*PetView
 )
 
-func NewPet359800019View(e *ent.Pet) *Pet359800019View {
+func NewPetView(e *ent.Pet) *PetView {
 	if e == nil {
 		return nil
 	}
-	return &Pet359800019View{
+	return &PetView{
 		ID:   e.ID,
 		Name: e.Name,
 		Age:  e.Age,
 	}
 }
 
-func NewPet359800019Views(es []*ent.Pet) Pet359800019Views {
+func NewPetViews(es []*ent.Pet) PetViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(Pet359800019Views, len(es))
+	r := make(PetViews, len(es))
 	for i, e := range es {
-		r[i] = NewPet359800019View(e)
+		r[i] = NewPetView(e)
 	}
 	return r
 }

--- a/internal/simple/ent/http/update.go
+++ b/internal/simple/ent/http/update.go
@@ -81,7 +81,7 @@ func (h CategoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("category rendered", zap.Uint64("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCategory4094953247View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCategoryView(e), w)
 }
 
 // Update updates a given ent.Collar and saves the changes to the database.
@@ -148,7 +148,7 @@ func (h CollarHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("collar rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewCollar1522160880View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewCollarView(e), w)
 }
 
 // Update updates a given ent.Owner and saves the changes to the database.
@@ -217,7 +217,7 @@ func (h OwnerHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("owner rendered", zap.String("id", id.String()))
-	easyjson.MarshalToHTTPResponseWriter(NewOwner139708381View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewOwnerView(e), w)
 }
 
 // Update updates a given ent.Pet and saves the changes to the database.
@@ -293,5 +293,5 @@ func (h PetHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("pet rendered", zap.String("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewPet359800019View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewPetView(e), w)
 }

--- a/internal/simple/ent/openapi.json
+++ b/internal/simple/ent/openapi.json
@@ -587,7 +587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PetView"
+                  "$ref": "#/components/schemas/PetWithOwnerAndPetOwnerView"
                 }
               }
             }
@@ -1068,7 +1068,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PetView"
+                  "$ref": "#/components/schemas/PetWithOwnerAndPetOwnerView"
                 }
               }
             }
@@ -1431,7 +1431,40 @@
           }
         }
       },
+      "CategoryWithOwnerAndPetAndPetOwnerView": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "CollarView": {
+        "type": "object",
+        "required": [
+          "color",
+          "id"
+        ],
+        "properties": {
+          "color": {
+            "type": "string",
+            "example": "green"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "CollarWithOwnerAndPetAndPetOwnerView": {
         "type": "object",
         "required": [
           "color",
@@ -1468,6 +1501,26 @@
           }
         }
       },
+      "OwnerWithPetAndPetOwnerView": {
+        "type": "object",
+        "required": [
+          "age",
+          "id",
+          "name"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "PetView": {
         "type": "object",
         "required": [
@@ -1485,6 +1538,35 @@
           },
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "PetWithOwnerAndPetOwnerView": {
+        "type": "object",
+        "required": [
+          "age",
+          "id",
+          "name"
+        ],
+        "properties": {
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "friends": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PetWithOwnerAndPetOwnerView"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/OwnerWithPetAndPetOwnerView"
           }
         }
       }

--- a/internal/simple/ent/openapi.json
+++ b/internal/simple/ent/openapi.json
@@ -46,7 +46,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category4094953247View"
+                    "$ref": "#/components/schemas/CategoryView"
                   }
                 }
               }
@@ -100,7 +100,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -140,7 +140,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -239,7 +239,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Category4094953247View"
+                  "$ref": "#/components/schemas/CategoryView"
                 }
               }
             }
@@ -302,7 +302,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -356,7 +356,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Collar1522160880View"
+                    "$ref": "#/components/schemas/CollarView"
                   }
                 }
               }
@@ -408,7 +408,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -448,7 +448,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -545,7 +545,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -587,7 +587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet1876743790View"
+                  "$ref": "#/components/schemas/PetView"
                 }
               }
             }
@@ -640,7 +640,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Owner139708381View"
+                    "$ref": "#/components/schemas/OwnerView"
                   }
                 }
               }
@@ -699,7 +699,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -738,7 +738,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -840,7 +840,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -902,7 +902,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -956,7 +956,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -1029,7 +1029,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet359800019View"
+                  "$ref": "#/components/schemas/PetView"
                 }
               }
             }
@@ -1068,7 +1068,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet1876743790View"
+                  "$ref": "#/components/schemas/PetView"
                 }
               }
             }
@@ -1184,7 +1184,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet359800019View"
+                  "$ref": "#/components/schemas/PetView"
                 }
               }
             }
@@ -1246,7 +1246,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Category4094953247View"
+                    "$ref": "#/components/schemas/CategoryView"
                   }
                 }
               }
@@ -1290,7 +1290,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Collar1522160880View"
+                  "$ref": "#/components/schemas/CollarView"
                 }
               }
             }
@@ -1352,7 +1352,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pet359800019View"
+                    "$ref": "#/components/schemas/PetView"
                   }
                 }
               }
@@ -1395,7 +1395,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Owner139708381View"
+                  "$ref": "#/components/schemas/OwnerView"
                 }
               }
             }
@@ -1415,7 +1415,7 @@
   },
   "components": {
     "schemas": {
-      "Category4094953247View": {
+      "CategoryView": {
         "type": "object",
         "required": [
           "id",
@@ -1431,7 +1431,7 @@
           }
         }
       },
-      "Collar1522160880View": {
+      "CollarView": {
         "type": "object",
         "required": [
           "color",
@@ -1448,7 +1448,7 @@
           }
         }
       },
-      "Owner139708381View": {
+      "OwnerView": {
         "type": "object",
         "required": [
           "age",
@@ -1468,36 +1468,7 @@
           }
         }
       },
-      "Pet1876743790View": {
-        "type": "object",
-        "required": [
-          "age",
-          "id",
-          "name"
-        ],
-        "properties": {
-          "age": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "friends": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Pet359800019View"
-            }
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "owner": {
-            "$ref": "#/components/schemas/Owner139708381View"
-          }
-        }
-      },
-      "Pet359800019View": {
+      "PetView": {
         "type": "object",
         "required": [
           "age",

--- a/internal/uuid/ent/http/create.go
+++ b/internal/uuid/ent/http/create.go
@@ -57,5 +57,5 @@ func (h UserHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("user rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewUser3451555716View(ret), w)
+	easyjson.MarshalToHTTPResponseWriter(NewUserView(ret), w)
 }

--- a/internal/uuid/ent/http/easyjson.go
+++ b/internal/uuid/ent/http/easyjson.go
@@ -18,147 +18,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp(in *jlexer.Lexer, out *UserUpdateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "uuid":
-			if in.IsNull() {
-				in.Skip()
-				out.UUID = nil
-			} else {
-				if out.UUID == nil {
-					out.UUID = new(uuid.UUID)
-				}
-				if data := in.UnsafeBytes(); in.Ok() {
-					in.AddError((*out.UUID).UnmarshalText(data))
-				}
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp(out *jwriter.Writer, in UserUpdateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"uuid\":"
-		out.RawString(prefix[1:])
-		if in.UUID == nil {
-			out.RawString("null")
-		} else {
-			out.RawText((*in.UUID).MarshalText())
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v UserUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *UserUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp1(in *jlexer.Lexer, out *UserCreateRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "uuid":
-			if in.IsNull() {
-				in.Skip()
-				out.UUID = nil
-			} else {
-				if out.UUID == nil {
-					out.UUID = new(uuid.UUID)
-				}
-				if data := in.UnsafeBytes(); in.Ok() {
-					in.AddError((*out.UUID).UnmarshalText(data))
-				}
-			}
-		default:
-			in.AddError(&jlexer.LexerError{
-				Offset: in.GetPos(),
-				Reason: "unknown field",
-				Data:   key,
-			})
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp1(out *jwriter.Writer, in UserCreateRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"uuid\":"
-		out.RawString(prefix[1:])
-		if in.UUID == nil {
-			out.RawString("null")
-		} else {
-			out.RawText((*in.UUID).MarshalText())
-		}
-	}
-	out.RawByte('}')
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v UserCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp1(w, v)
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *UserCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp1(l, v)
-}
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp2(in *jlexer.Lexer, out *User3451555716Views) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp(in *jlexer.Lexer, out *UserViews) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		in.Skip()
@@ -167,21 +27,21 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp2(in *jlexer.
 		in.Delim('[')
 		if *out == nil {
 			if !in.IsDelim(']') {
-				*out = make(User3451555716Views, 0, 8)
+				*out = make(UserViews, 0, 8)
 			} else {
-				*out = User3451555716Views{}
+				*out = UserViews{}
 			}
 		} else {
 			*out = (*out)[:0]
 		}
 		for !in.IsDelim(']') {
-			var v1 *User3451555716View
+			var v1 *UserView
 			if in.IsNull() {
 				in.Skip()
 				v1 = nil
 			} else {
 				if v1 == nil {
-					v1 = new(User3451555716View)
+					v1 = new(UserView)
 				}
 				(*v1).UnmarshalEasyJSON(in)
 			}
@@ -194,7 +54,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp2(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp2(out *jwriter.Writer, in User3451555716Views) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp(out *jwriter.Writer, in UserViews) {
 	if in == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 		out.RawString("null")
 	} else {
@@ -214,15 +74,15 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp2(out *jwrite
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v User3451555716Views) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp2(w, v)
+func (v UserViews) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *User3451555716Views) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp2(l, v)
+func (v *UserViews) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp(l, v)
 }
-func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp3(in *jlexer.Lexer, out *User3451555716View) {
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp1(in *jlexer.Lexer, out *UserView) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -261,7 +121,7 @@ func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp3(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp3(out *jwriter.Writer, in User3451555716View) {
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp1(out *jwriter.Writer, in UserView) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -285,12 +145,152 @@ func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp3(out *jwrite
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v User3451555716View) MarshalEasyJSON(w *jwriter.Writer) {
+func (v UserView) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp1(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *UserView) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp1(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp2(in *jlexer.Lexer, out *UserUpdateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "uuid":
+			if in.IsNull() {
+				in.Skip()
+				out.UUID = nil
+			} else {
+				if out.UUID == nil {
+					out.UUID = new(uuid.UUID)
+				}
+				if data := in.UnsafeBytes(); in.Ok() {
+					in.AddError((*out.UUID).UnmarshalText(data))
+				}
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp2(out *jwriter.Writer, in UserUpdateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"uuid\":"
+		out.RawString(prefix[1:])
+		if in.UUID == nil {
+			out.RawString("null")
+		} else {
+			out.RawText((*in.UUID).MarshalText())
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v UserUpdateRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp2(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *UserUpdateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp2(l, v)
+}
+func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp3(in *jlexer.Lexer, out *UserCreateRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "uuid":
+			if in.IsNull() {
+				in.Skip()
+				out.UUID = nil
+			} else {
+				if out.UUID == nil {
+					out.UUID = new(uuid.UUID)
+				}
+				if data := in.UnsafeBytes(); in.Ok() {
+					in.AddError((*out.UUID).UnmarshalText(data))
+				}
+			}
+		default:
+			in.AddError(&jlexer.LexerError{
+				Offset: in.GetPos(),
+				Reason: "unknown field",
+				Data:   key,
+			})
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp3(out *jwriter.Writer, in UserCreateRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"uuid\":"
+		out.RawString(prefix[1:])
+		if in.UUID == nil {
+			out.RawString("null")
+		} else {
+			out.RawText((*in.UUID).MarshalText())
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v UserCreateRequest) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonC5a4559bEncodeGithubComMasseelchElkInternalUuidEntHttp3(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *User3451555716View) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *UserCreateRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp3(l, v)
 }
 func easyjsonC5a4559bDecodeGithubComMasseelchElkInternalUuidEntHttp4(in *jlexer.Lexer, out *ErrResponse) {

--- a/internal/uuid/ent/http/list.go
+++ b/internal/uuid/ent/http/list.go
@@ -41,5 +41,5 @@ func (h *UserHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("users rendered", zap.Int("amount", len(es)))
-	easyjson.MarshalToHTTPResponseWriter(NewUser3451555716Views(es), w)
+	easyjson.MarshalToHTTPResponseWriter(NewUserViews(es), w)
 }

--- a/internal/uuid/ent/http/read.go
+++ b/internal/uuid/ent/http/read.go
@@ -44,5 +44,5 @@ func (h *UserHandler) Read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("user rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewUser3451555716View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewUserView(e), w)
 }

--- a/internal/uuid/ent/http/response.go
+++ b/internal/uuid/ent/http/response.go
@@ -78,32 +78,32 @@ func Unauthorized(w http.ResponseWriter, msg interface{}) (int, error) {
 }
 
 type (
-	// User3451555716View represents the data serialized for the following serialization group combinations:
+	// UserView represents the data serialized for the following serialization group combinations:
 	// []
-	User3451555716View struct {
+	UserView struct {
 		ID   int       `json:"id,omitempty"`
 		UUID uuid.UUID `json:"uuid,omitempty"`
 	}
-	User3451555716Views []*User3451555716View
+	UserViews []*UserView
 )
 
-func NewUser3451555716View(e *ent.User) *User3451555716View {
+func NewUserView(e *ent.User) *UserView {
 	if e == nil {
 		return nil
 	}
-	return &User3451555716View{
+	return &UserView{
 		ID:   e.ID,
 		UUID: e.UUID,
 	}
 }
 
-func NewUser3451555716Views(es []*ent.User) User3451555716Views {
+func NewUserViews(es []*ent.User) UserViews {
 	if len(es) == 0 {
 		return nil
 	}
-	r := make(User3451555716Views, len(es))
+	r := make(UserViews, len(es))
 	for i, e := range es {
-		r[i] = NewUser3451555716View(e)
+		r[i] = NewUserView(e)
 	}
 	return r
 }

--- a/internal/uuid/ent/http/update.go
+++ b/internal/uuid/ent/http/update.go
@@ -73,5 +73,5 @@ func (h UserHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	l.Info("user rendered", zap.Int("id", id))
-	easyjson.MarshalToHTTPResponseWriter(NewUser3451555716View(e), w)
+	easyjson.MarshalToHTTPResponseWriter(NewUserView(e), w)
 }

--- a/view.go
+++ b/view.go
@@ -94,19 +94,14 @@ func (v view) Name() (string, error) {
 		}
 	}
 
-	annotations, ok := v.Node.Annotations[elkSchemaName]
-	schemaAnnotation, canCast := annotations.(map[string]interface{})
-	if !ok || len(groups) == 0 || !canCast {
-
+	if len(groups) == 0 {
 		// if no annotations or no groups (should be same thing) there's only one view
 		return fmt.Sprintf("%sView", v.Node.Name), nil
 	}
 
-	for k, val := range schemaAnnotation {
-		gs, ok := val.(serialization.Groups)
-		if ok && len(gs) > 1 {
-			return fmt.Sprintf("%v%sView", v.Node.Name, k), nil
-		}
+	if strings.HasPrefix(groups[0], v.Node.Name) {
+		// special case to avoid repetitive names
+		return fmt.Sprintf("%sView", strings.Join(groups, "And")), nil
 	}
 
 	return fmt.Sprintf("%vWith%sView", v.Node.Name, strings.Join(groups, "And")), nil

--- a/view.go
+++ b/view.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	inflect "github.com/go-openapi/inflect"
 	"github.com/masseelch/elk/serialization"
-	"log"
 	"strings"
 )
 
@@ -71,8 +70,6 @@ func newViews(g *gen.Graph) (map[string]*mergedView, error) {
 			if mv, ok := m[v]; ok && !mv.Groups.Contains(gs) {
 				mv.Groups = append(mv.Groups, gs)
 			} else {
-				name, _ := r.Name()
-				log.Printf("name; groups: %s: %v", name, gs)
 				m[v] = &mergedView{
 					view:   *r,
 					Groups: serialization.Collection{gs},


### PR DESCRIPTION
1. Default to a simple name if no annotations
2. If there is a group, provide an english-sensible name using camelized
   group names. E.g. `PetWith{groupName1}And{groupName2}View`